### PR TITLE
Add workspace capabilities and OpenAPI contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ The backend should act as a product API and orchestration layer, not as a blind 
 This repository now starts as a JWT-protected Spring Boot API with:
 
 - a `/api/v1/me` endpoint for claim inspection and client/backend contract testing
+- a `/api/v1/workspace/capabilities` endpoint for the first backend-owned client contract
+- OpenAPI JSON published at `/v3/api-docs`
 - actuator health and info endpoints
 - optional audience validation for JWTs
 - Gradle wrapper and GitHub Actions CI

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.5.0'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/massimotter/weave/backend/config/OpenApiConfig.java
+++ b/src/main/java/com/massimotter/weave/backend/config/OpenApiConfig.java
@@ -1,0 +1,26 @@
+package com.massimotter.weave.backend.config;
+
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@SecurityScheme(
+        name = "bearer-jwt",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT")
+public class OpenApiConfig {
+
+    @Bean
+    OpenAPI weaveOpenApi() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Weave Backend API")
+                        .version("v1")
+                        .description("JWT-protected product API for workspace capabilities and orchestration."));
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/config/SecurityConfig.java
+++ b/src/main/java/com/massimotter/weave/backend/config/SecurityConfig.java
@@ -31,6 +31,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/actuator/health", "/actuator/info", "/error").permitAll()
+                        .requestMatchers("/v3/api-docs", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt ->
                         jwt.jwtAuthenticationConverter(jwtAuthenticationConverter())));

--- a/src/main/java/com/massimotter/weave/backend/controller/IdentityController.java
+++ b/src/main/java/com/massimotter/weave/backend/controller/IdentityController.java
@@ -1,5 +1,12 @@
 package com.massimotter.weave.backend.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import com.massimotter.weave.backend.model.AuthenticatedUserResponse;
 import java.util.Collection;
 import java.util.List;
@@ -12,9 +19,21 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1")
+@Tag(name = "Identity", description = "Authenticated caller introspection endpoints.")
 public class IdentityController {
 
     @GetMapping("/me")
+    @Operation(
+            summary = "Get the authenticated caller profile",
+            description = "Returns the normalized identity claims available to the Weave backend.",
+            security = @SecurityRequirement(name = "bearer-jwt"))
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Authenticated caller details.",
+                    content = @Content(schema = @Schema(implementation = AuthenticatedUserResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Missing or invalid bearer token.")
+    })
     public AuthenticatedUserResponse me(@AuthenticationPrincipal Jwt jwt) {
         return new AuthenticatedUserResponse(
                 jwt.getSubject(),

--- a/src/main/java/com/massimotter/weave/backend/controller/WorkspaceController.java
+++ b/src/main/java/com/massimotter/weave/backend/controller/WorkspaceController.java
@@ -1,0 +1,42 @@
+package com.massimotter.weave.backend.controller;
+
+import com.massimotter.weave.backend.model.WorkspaceCapabilitiesResponse;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityStatusResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/workspace")
+@Tag(name = "Workspace", description = "Workspace readiness and capability endpoints.")
+public class WorkspaceController {
+
+    @GetMapping("/capabilities")
+    @Operation(
+            summary = "Get workspace capability readiness",
+            description = "Returns the backend-owned workspace capability snapshot consumed by the Weave client.",
+            security = @SecurityRequirement(name = "bearer-jwt"))
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Workspace capability snapshot.",
+                    content = @Content(schema = @Schema(implementation = WorkspaceCapabilitiesResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Missing or invalid bearer token.")
+    })
+    public WorkspaceCapabilitiesResponse capabilities() {
+        return new WorkspaceCapabilitiesResponse(
+                new WorkspaceCapabilityStatusResponse(true, WorkspaceCapabilityReadiness.READY),
+                new WorkspaceCapabilityStatusResponse(true, WorkspaceCapabilityReadiness.READY),
+                new WorkspaceCapabilityStatusResponse(true, WorkspaceCapabilityReadiness.READY),
+                new WorkspaceCapabilityStatusResponse(false, WorkspaceCapabilityReadiness.UNAVAILABLE),
+                new WorkspaceCapabilityStatusResponse(false, WorkspaceCapabilityReadiness.UNAVAILABLE));
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/model/WorkspaceCapabilitiesResponse.java
+++ b/src/main/java/com/massimotter/weave/backend/model/WorkspaceCapabilitiesResponse.java
@@ -1,0 +1,12 @@
+package com.massimotter.weave.backend.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Workspace capability snapshot exposed to Weave clients.")
+public record WorkspaceCapabilitiesResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) WorkspaceCapabilityStatusResponse shellAccess,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) WorkspaceCapabilityStatusResponse chat,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) WorkspaceCapabilityStatusResponse files,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) WorkspaceCapabilityStatusResponse calendar,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) WorkspaceCapabilityStatusResponse boards) {
+}

--- a/src/main/java/com/massimotter/weave/backend/model/WorkspaceCapabilityReadiness.java
+++ b/src/main/java/com/massimotter/weave/backend/model/WorkspaceCapabilityReadiness.java
@@ -1,0 +1,23 @@
+package com.massimotter.weave.backend.model;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Readiness states returned for workspace capabilities.")
+public enum WorkspaceCapabilityReadiness {
+    READY("ready"),
+    DEGRADED("degraded"),
+    BLOCKED("blocked"),
+    UNAVAILABLE("unavailable");
+
+    private final String value;
+
+    WorkspaceCapabilityReadiness(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String value() {
+        return value;
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/model/WorkspaceCapabilityStatusResponse.java
+++ b/src/main/java/com/massimotter/weave/backend/model/WorkspaceCapabilityStatusResponse.java
@@ -1,0 +1,11 @@
+package com.massimotter.weave.backend.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Availability and readiness state for one workspace capability.")
+public record WorkspaceCapabilityStatusResponse(
+        @Schema(description = "Whether the capability is enabled for this workspace.", example = "true")
+        boolean enabled,
+        @Schema(description = "Current readiness state for this capability.")
+        WorkspaceCapabilityReadiness readiness) {
+}

--- a/src/test/java/com/massimotter/weave/backend/controller/OpenApiDocumentationTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/OpenApiDocumentationTest.java
@@ -1,0 +1,38 @@
+package com.massimotter.weave.backend.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.startsWith;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(properties = {
+        "spring.security.oauth2.resourceserver.jwt.issuer-uri=https://auth.example.invalid/realms/weave"
+})
+@AutoConfigureMockMvc
+class OpenApiDocumentationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JwtDecoder jwtDecoder;
+
+    @Test
+    void exposesOpenApiDescription() throws Exception {
+        mockMvc.perform(get("/v3/api-docs"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.openapi").value(startsWith("3.")))
+                .andExpect(jsonPath("$.info.title").value("Weave Backend API"))
+                .andExpect(jsonPath("$.paths['/api/v1/me']").exists())
+                .andExpect(jsonPath("$.paths['/api/v1/workspace/capabilities']").exists())
+                .andExpect(jsonPath("$.components.securitySchemes['bearer-jwt'].type").value("http"));
+    }
+}

--- a/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
@@ -1,0 +1,48 @@
+package com.massimotter.weave.backend.controller;
+
+import com.massimotter.weave.backend.config.SecurityConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = WorkspaceController.class)
+@Import(SecurityConfig.class)
+@org.springframework.test.context.TestPropertySource(properties = {
+        "spring.security.oauth2.resourceserver.jwt.issuer-uri=https://auth.example.invalid/realms/weave"
+})
+class WorkspaceControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JwtDecoder jwtDecoder;
+
+    @Test
+    void returnsStaticWorkspaceCapabilities() throws Exception {
+        mockMvc.perform(get("/api/v1/workspace/capabilities").with(jwt()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.shellAccess.enabled").value(true))
+                .andExpect(jsonPath("$.shellAccess.readiness").value("ready"))
+                .andExpect(jsonPath("$.chat.readiness").value("ready"))
+                .andExpect(jsonPath("$.files.readiness").value("ready"))
+                .andExpect(jsonPath("$.calendar.enabled").value(false))
+                .andExpect(jsonPath("$.calendar.readiness").value("unavailable"))
+                .andExpect(jsonPath("$.boards.readiness").value("unavailable"));
+    }
+
+    @Test
+    void rejectsAnonymousRequests() throws Exception {
+        mockMvc.perform(get("/api/v1/workspace/capabilities"))
+                .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
Closes #1
Refs #2

## What changed
- added a first backend-owned capability contract at `GET /api/v1/workspace/capabilities`
- added OpenAPI JSON publication at `/v3/api-docs`
- documented JWT bearer auth in the generated contract and annotated `/api/v1/me`
- added controller and docs smoke tests for the new API surface

## Why
- the backend needed a stable, versioned contract that the Flutter app can consume without reintroducing Matrix or Nextcloud proxy behavior
- OpenAPI gives the client and infrastructure work a shared reference point for the first backend API slice

## Validation
- `docker run --rm -u $(id -u):$(id -g) -e HOME=/tmp -e GRADLE_USER_HOME=/tmp/.gradle -v /Users/flotterotter/code/weave-backend:/workspace -w /workspace eclipse-temurin:17-jdk ./gradlew --no-daemon test`
