### PR TITLE
docs(drift): add AGENTS.md, remove stale paths and incorrect claims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# Weave Backend Repository Instructions
+
+`weave-backend` is a Spring Boot JWT resource server for the Weave product family. It validates access tokens issued by the Keycloak realm and owns server-side product APIs and orchestration workflows. It must not become a generic proxy for Matrix, Nextcloud, or Keycloak end-user traffic that the Flutter client already handles natively.
+
+Placement rules:
+- `config/` for Spring configuration and security setup
+- `controller/` for REST endpoints and request/response mapping only — keep controllers thin
+- `model/` for response and request DTOs
+- `service/` for business logic and orchestration when the domain grows beyond single-class controllers
+
+Ownership boundary:
+- The backend validates the OIDC issuer always and audience optionally; do not remove either check
+- Do not add endpoints that blindly relay user bearer tokens to Matrix, Nextcloud, or Keycloak
+- Backend integrations with downstream services must use service-account credentials or documented token exchange, not forwarded user tokens
+- New endpoints belong under the existing `/api/v1/` namespace unless there is a versioning reason to break that
+
+App-config alignment:
+- OIDC issuer is configured via `WEAVE_OIDC_ISSUER_URI`; optional audience validation via `WEAVE_OIDC_REQUIRED_AUDIENCE`
+- App redirect URIs (for cross-repo reference): `com.massimotter.weave:/oauthredirect` and `com.massimotter.weave:/logout`
+- Local development stacks may legitimately use `http://` issuers and service URLs
+
+Validation:
+- `./gradlew test`
+- `./gradlew check`

--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ docker run --rm \
 
 ## Architecture alignment
 
-See [docs/architecture-alignment.md](/Users/flotterotter/code/weave-backend/docs/architecture-alignment.md) and the issue drafts under [docs/issues](/Users/flotterotter/code/weave-backend/docs/issues).
+See [docs/architecture-alignment.md](docs/architecture-alignment.md) and the issue drafts under [docs/issues](docs/issues).

--- a/docs/architecture-alignment.md
+++ b/docs/architecture-alignment.md
@@ -31,9 +31,9 @@ Own the runnable environment and integration contract:
 
 ## Gaps found in the current state
 
-1. `weave` uses `com.massimotter.weave:/oauthredirect` and `com.massimotter.weave:/logout`, while `weave-inf` currently registers `weaveapp://login/callback` for the `weave-app` Keycloak client.
-2. `weave` derives `https://nextcloud.<base-domain>`, while `weave-inf` currently exposes Nextcloud on `files.<tenant_domain>`.
-3. `weave` requires an HTTPS issuer and enforces HTTPS for live Nextcloud use, while `weave-inf` still defaults to `http://...:8090` local ingress.
+1. ~~`weave-inf` registered `weaveapp://login/callback`~~ — resolved: `weave-inf` now registers `com.massimotter.weave:/oauthredirect` and `com.massimotter.weave:/logout` for the `weave-app` Keycloak client, matching the app contract.
+2. ~~`weave-inf` exposed Nextcloud on `files.<tenant_domain>`~~ — resolved: `weave-inf` now uses `nextcloud.<tenant_domain>`, matching the app derivation rule.
+3. `weave-inf` still defaults to an HTTP-only local ingress. Note: per the app AGENTS.md, local development stacks may legitimately use `http://` issuers and service URLs; HTTPS is recommended for production deployments.
 4. The original `weave-backend` spike assumed that user bearer tokens could be forwarded directly into Nextcloud and Matrix calls. That is the wrong default boundary for this stack.
 5. The original backend spike did not compile in a clean Gradle/JDK environment because it used `WebClient` types without the needed reactive dependency and mixed incompatible OAuth client wiring.
 
@@ -69,6 +69,6 @@ The safest first shape is therefore:
 
 Issue-ready drafts live under:
 
-- [docs/issues/weave](/Users/flotterotter/code/weave-backend/docs/issues/weave)
-- [docs/issues/weave-inf](/Users/flotterotter/code/weave-backend/docs/issues/weave-inf)
-- [docs/issues/weave-backend](/Users/flotterotter/code/weave-backend/docs/issues/weave-backend)
+- [docs/issues/weave](issues/weave)
+- [docs/issues/weave-inf](issues/weave-inf)
+- [docs/issues/weave-backend](issues/weave-backend)

--- a/docs/architecture-alignment.md
+++ b/docs/architecture-alignment.md
@@ -31,8 +31,8 @@ Own the runnable environment and integration contract:
 
 ## Gaps found in the current state
 
-1. ~~`weave-inf` registered `weaveapp://login/callback`~~ — resolved: `weave-inf` now registers `com.massimotter.weave:/oauthredirect` and `com.massimotter.weave:/logout` for the `weave-app` Keycloak client, matching the app contract.
-2. ~~Nextcloud hostname mismatch~~ — resolved: `weave-inf` now uses `nextcloud.<tenant_domain>`, matching the app derivation rule.
+1. ~~`weave-inf` registered `weaveapp://login/callback`~~ — resolved in Terraform source: `weave-inf` now declares `com.massimotter.weave:/oauthredirect` and `com.massimotter.weave:/logout` for the `weave-app` Keycloak client. Requires `terraform apply` in `weave-workspace/02-keycloak-setup` to propagate to a running Keycloak instance.
+2. ~~Nextcloud hostname mismatch~~ — resolved in Terraform source: `weave-inf` now declares `nextcloud.<tenant_domain>`, matching the app derivation rule. Requires `terraform apply` to propagate.
 3. `weave-inf` still defaults to an HTTP-only local ingress. Note: per the app AGENTS.md, local development stacks may legitimately use `http://` issuers and service URLs; HTTPS is recommended for production deployments.
 4. The original `weave-backend` spike assumed that user bearer tokens could be forwarded directly into Nextcloud and Matrix calls. That is the wrong default boundary for this stack.
 5. The original backend spike did not compile in a clean Gradle/JDK environment because it used `WebClient` types without the needed reactive dependency and mixed incompatible OAuth client wiring.

--- a/docs/architecture-alignment.md
+++ b/docs/architecture-alignment.md
@@ -32,7 +32,7 @@ Own the runnable environment and integration contract:
 ## Gaps found in the current state
 
 1. ~~`weave-inf` registered `weaveapp://login/callback`~~ — resolved: `weave-inf` now registers `com.massimotter.weave:/oauthredirect` and `com.massimotter.weave:/logout` for the `weave-app` Keycloak client, matching the app contract.
-2. ~~`weave-inf` exposed Nextcloud on `files.<tenant_domain>`~~ — resolved: `weave-inf` now uses `nextcloud.<tenant_domain>`, matching the app derivation rule.
+2. ~~Nextcloud hostname mismatch~~ — resolved: `weave-inf` now uses `nextcloud.<tenant_domain>`, matching the app derivation rule.
 3. `weave-inf` still defaults to an HTTP-only local ingress. Note: per the app AGENTS.md, local development stacks may legitimately use `http://` issuers and service URLs; HTTPS is recommended for production deployments.
 4. The original `weave-backend` spike assumed that user bearer tokens could be forwarded directly into Nextcloud and Matrix calls. That is the wrong default boundary for this stack.
 5. The original backend spike did not compile in a clean Gradle/JDK environment because it used `WebClient` types without the needed reactive dependency and mixed incompatible OAuth client wiring.

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -4,15 +4,15 @@ These markdown files are written so they can be copied almost directly into GitH
 
 ## `weave`
 
-- [Align native OIDC registration and derived endpoints](/Users/flotterotter/code/weave-backend/docs/issues/weave/align-native-oidc-and-derived-endpoints.md)
-- [Introduce a backend API boundary in the Flutter client](/Users/flotterotter/code/weave-backend/docs/issues/weave/introduce-backend-api-boundary.md)
+- [Align native OIDC registration and derived endpoints](weave/align-native-oidc-and-derived-endpoints.md)
+- [Introduce a backend API boundary in the Flutter client](weave/introduce-backend-api-boundary.md)
 
 ## `weave-inf`
 
-- [Enable local TLS and align public hostnames](/Users/flotterotter/code/weave-backend/docs/issues/weave-inf/enable-local-tls-and-align-public-hostnames.md)
-- [Deploy weave-backend and finalize the Keycloak contract](/Users/flotterotter/code/weave-backend/docs/issues/weave-inf/deploy-weave-backend-and-finalize-keycloak-contract.md)
+- [Enable local TLS and align public hostnames](weave-inf/enable-local-tls-and-align-public-hostnames.md)
+- [Deploy weave-backend and finalize the Keycloak contract](weave-inf/deploy-weave-backend-and-finalize-keycloak-contract.md)
 
 ## `weave-backend`
 
-- [Establish the backend API and OpenAPI contract](/Users/flotterotter/code/weave-backend/docs/issues/weave-backend/establish-backend-api-and-openapi-contract.md)
-- [Implement server-owned integrations only](/Users/flotterotter/code/weave-backend/docs/issues/weave-backend/implement-server-owned-integrations-only.md)
+- [Establish the backend API and OpenAPI contract](weave-backend/establish-backend-api-and-openapi-contract.md)
+- [Implement server-owned integrations only](weave-backend/implement-server-owned-integrations-only.md)

--- a/docs/issues/weave-inf/enable-local-tls-and-align-public-hostnames.md
+++ b/docs/issues/weave-inf/enable-local-tls-and-align-public-hostnames.md
@@ -16,7 +16,7 @@
 ## Acceptance criteria
 
 - the stack can be reached over HTTPS with the configured hostnames
-- Export the final browser-facing URLs as Terraform outputs or generated install metadata for client/backend consumers
-- Nextcloud uses `nextcloud.<tenant_domain>` (already aligned).
+- browser-facing URLs (`auth.<tenant_domain>`, `mas.<tenant_domain>`, `matrix.<tenant_domain>`, `nextcloud.<tenant_domain>`) are exported as Terraform outputs or written to the generated install metadata
+- ~~Nextcloud uses `nextcloud.<tenant_domain>`~~ (resolved by `weave-inf` Terraform update; requires `terraform apply` to propagate)
 - installer output shows the HTTPS URLs that the client and backend should consume
 - local bootstrap docs include the trusted certificate/dev CA step needed for mobile or desktop testing

--- a/docs/issues/weave-inf/enable-local-tls-and-align-public-hostnames.md
+++ b/docs/issues/weave-inf/enable-local-tls-and-align-public-hostnames.md
@@ -2,12 +2,7 @@
 
 ## Problem
 
-The Flutter app requires:
-
-- an HTTPS OIDC issuer
-- HTTPS Nextcloud access for the live integration flow
-
-`weave-inf` still defaults to an HTTP ingress on `:8090`, and it exposes Nextcloud on `files.<tenant_domain>` while the app derives `nextcloud.<base-domain>`.
+`weave-inf` still defaults to an HTTP-only local ingress. Note: per the app AGENTS.md, local development stacks may legitimately use `http://` issuers and service URLs; HTTPS remains recommended for production deployments and real device testing.
 
 ## Proposal
 
@@ -17,11 +12,11 @@ The Flutter app requires:
   - `mas.<tenant_domain>`
   - `matrix.<tenant_domain>`
   - `nextcloud.<tenant_domain>`
-- Export the final browser-facing URLs as Terraform outputs or generated install metadata for client/backend consumers
 
 ## Acceptance criteria
 
 - the stack can be reached over HTTPS with the configured hostnames
-- Nextcloud uses the final agreed hostname instead of `files.<tenant_domain>`
+- Export the final browser-facing URLs as Terraform outputs or generated install metadata for client/backend consumers
+- Nextcloud uses `nextcloud.<tenant_domain>` (already aligned).
 - installer output shows the HTTPS URLs that the client and backend should consume
 - local bootstrap docs include the trusted certificate/dev CA step needed for mobile or desktop testing

--- a/docs/issues/weave/align-native-oidc-and-derived-endpoints.md
+++ b/docs/issues/weave/align-native-oidc-and-derived-endpoints.md
@@ -8,7 +8,7 @@
 - OIDC post-logout redirect: `com.massimotter.weave:/logout`
 - derived Nextcloud URL: `https://nextcloud.<base-domain>`
 
-The current `weave-inf` setup still registers `weaveapp://login/callback` for the Keycloak client and exposes Nextcloud on `files.<tenant_domain>`, so the default infrastructure contract does not match the client code.
+The current `weave-inf` setup now registers `com.massimotter.weave:/oauthredirect` and `com.massimotter.weave:/logout` for the `weave-app` Keycloak client and exposes Nextcloud on `nextcloud.<tenant_domain>`, so the infrastructure contract now matches the client code.
 
 ## Proposal
 

--- a/docs/issues/weave/align-native-oidc-and-derived-endpoints.md
+++ b/docs/issues/weave/align-native-oidc-and-derived-endpoints.md
@@ -1,14 +1,20 @@
 # Align native OIDC registration and derived endpoints
 
+> **Status: Resolved** — `weave-inf` now uses the correct native redirect URIs and exposes Nextcloud on `nextcloud.<base-domain>`. The Proposal and Acceptance Criteria below describe the remaining documentation work.
+
 ## Problem
 
-`weave` currently expects:
+`weave` expected:
 
 - OIDC redirect: `com.massimotter.weave:/oauthredirect`
 - OIDC post-logout redirect: `com.massimotter.weave:/logout`
 - derived Nextcloud URL: `https://nextcloud.<base-domain>`
 
-The current `weave-inf` setup now registers `com.massimotter.weave:/oauthredirect` and `com.massimotter.weave:/logout` for the `weave-app` Keycloak client and exposes Nextcloud on `nextcloud.<tenant_domain>`, so the infrastructure contract now matches the client code.
+The original `weave-inf` setup had registered `weaveapp://login/callback` for the Keycloak client and exposed Nextcloud on `files.<tenant_domain>`, so the default infrastructure contract did not match the client code.
+
+## Resolution
+
+`weave-inf` was updated to register `com.massimotter.weave:/oauthredirect` and `com.massimotter.weave:/logout` for the `weave-app` Keycloak client and to expose Nextcloud on `nextcloud.<base-domain>`, bringing the infrastructure contract into alignment with the client expectations.
 
 ## Proposal
 

--- a/docs/issues/weave/align-native-oidc-and-derived-endpoints.md
+++ b/docs/issues/weave/align-native-oidc-and-derived-endpoints.md
@@ -1,6 +1,6 @@
 # Align native OIDC registration and derived endpoints
 
-> **Status: Resolved** — `weave-inf` now uses the correct native redirect URIs and exposes Nextcloud on `nextcloud.<base-domain>`. The Proposal and Acceptance Criteria below describe the remaining documentation work.
+> **Status: Resolved in Terraform source** — `weave-inf` now declares the correct native redirect URIs and `nextcloud.<base-domain>`. A `terraform apply` in `weave-workspace/02-keycloak-setup` is required to propagate the changes to a running Keycloak instance.
 
 ## Problem
 


### PR DESCRIPTION
Refs masssi164/weave#28

Adds AGENTS.md. Removes absolute filesystem paths from docs. Corrects stale redirect URI and HTTPS-only assumptions.