### PR TITLE
feat(security): first-party identity contract — audience, scope, caller binding

### DIFF
--- a/src/main/java/com/massimotter/weave/backend/config/JwtDecoderConfig.java
+++ b/src/main/java/com/massimotter/weave/backend/config/JwtDecoderConfig.java
@@ -26,14 +26,19 @@ public class JwtDecoderConfig {
         if (weaveSecurityProperties.hasRequiredAudience()) {
             validator = new DelegatingOAuth2TokenValidator<>(
                     validator,
-                    jwt -> hasRequiredAudience(jwt, weaveSecurityProperties.requiredAudience().trim()));
+                    requiredAudienceValidator(weaveSecurityProperties.requiredAudience()));
         }
 
         jwtDecoder.setJwtValidator(validator);
         return jwtDecoder;
     }
 
-    private OAuth2TokenValidatorResult hasRequiredAudience(Jwt jwt, String requiredAudience) {
+    static OAuth2TokenValidator<Jwt> requiredAudienceValidator(String requiredAudience) {
+        String normalizedRequiredAudience = requiredAudience.trim();
+        return jwt -> hasRequiredAudience(jwt, normalizedRequiredAudience);
+    }
+
+    private static OAuth2TokenValidatorResult hasRequiredAudience(Jwt jwt, String requiredAudience) {
         List<String> audiences = jwt.getAudience();
         if (audiences != null && audiences.contains(requiredAudience)) {
             return OAuth2TokenValidatorResult.success();
@@ -44,7 +49,7 @@ public class JwtDecoderConfig {
                         "The token is missing the required audience '" + requiredAudience + "'."));
     }
 
-    private org.springframework.security.oauth2.core.OAuth2Error error(String code, String description) {
+    private static org.springframework.security.oauth2.core.OAuth2Error error(String code, String description) {
         return new org.springframework.security.oauth2.core.OAuth2Error(code, description, null);
     }
 }

--- a/src/main/java/com/massimotter/weave/backend/config/SecurityConfig.java
+++ b/src/main/java/com/massimotter/weave/backend/config/SecurityConfig.java
@@ -24,6 +24,8 @@ import org.springframework.security.web.SecurityFilterChain;
 @EnableMethodSecurity
 public class SecurityConfig {
 
+    private static final String WORKSPACE_SCOPE_AUTHORITY = "SCOPE_weave:workspace";
+
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
@@ -32,6 +34,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/actuator/health", "/actuator/info", "/error").permitAll()
                         .requestMatchers("/v3/api-docs", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/api/v1/**").hasAuthority(WORKSPACE_SCOPE_AUTHORITY)
                         .anyRequest().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt ->
                         jwt.jwtAuthenticationConverter(jwtAuthenticationConverter())));
@@ -42,6 +45,10 @@ public class SecurityConfig {
     @Bean
     Converter<Jwt, ? extends AbstractAuthenticationToken> jwtAuthenticationConverter() {
         JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
+        // First-party caller binding is carried by Keycloak as azp/client_id
+        // for the Flutter client com.massimotter.weave. Do not treat that
+        // claim as an authority; issuer/audience validation establishes the
+        // token contract and scopes grant API access.
         converter.setJwtGrantedAuthoritiesConverter(this::extractAuthorities);
         return converter;
     }

--- a/src/main/java/com/massimotter/weave/backend/controller/IdentityController.java
+++ b/src/main/java/com/massimotter/weave/backend/controller/IdentityController.java
@@ -32,7 +32,8 @@ public class IdentityController {
                     responseCode = "200",
                     description = "Authenticated caller details.",
                     content = @Content(schema = @Schema(implementation = AuthenticatedUserResponse.class))),
-            @ApiResponse(responseCode = "401", description = "Missing or invalid bearer token.")
+            @ApiResponse(responseCode = "401", description = "Missing or invalid bearer token."),
+            @ApiResponse(responseCode = "403", description = "Bearer token is missing the weave:workspace scope.")
     })
     public AuthenticatedUserResponse me(@AuthenticationPrincipal Jwt jwt) {
         return new AuthenticatedUserResponse(

--- a/src/main/java/com/massimotter/weave/backend/controller/WorkspaceController.java
+++ b/src/main/java/com/massimotter/weave/backend/controller/WorkspaceController.java
@@ -29,7 +29,8 @@ public class WorkspaceController {
                     responseCode = "200",
                     description = "Workspace capability snapshot.",
                     content = @Content(schema = @Schema(implementation = WorkspaceCapabilitiesResponse.class))),
-            @ApiResponse(responseCode = "401", description = "Missing or invalid bearer token.")
+            @ApiResponse(responseCode = "401", description = "Missing or invalid bearer token."),
+            @ApiResponse(responseCode = "403", description = "Bearer token is missing the weave:workspace scope.")
     })
     public WorkspaceCapabilitiesResponse capabilities() {
         return new WorkspaceCapabilitiesResponse(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,8 @@ spring:
     oauth2:
       resourceserver:
         jwt:
+          # Required. Keycloak realm issuer used to validate JWT iss, exp, nbf, and signature.
+          # Example: https://auth.example.com/realms/weave
           issuer-uri: ${WEAVE_OIDC_ISSUER_URI}
 
 management:
@@ -22,4 +24,6 @@ management:
 
 weave:
   security:
+    # Optional. When set, JWT aud must include this backend audience or the request is rejected with 401.
+    # Leave empty only for local bootstrap environments before the Keycloak audience mapper is in place.
     required-audience: ${WEAVE_OIDC_REQUIRED_AUDIENCE:}

--- a/src/test/java/com/massimotter/weave/backend/config/FirstPartyIdentityContractTest.java
+++ b/src/test/java/com/massimotter/weave/backend/config/FirstPartyIdentityContractTest.java
@@ -1,0 +1,128 @@
+package com.massimotter.weave.backend.config;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.security.oauth2.jwt.JwtValidationException;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(properties = {
+        "spring.security.oauth2.resourceserver.jwt.issuer-uri=https://auth.example.invalid/realms/weave",
+        "weave.security.required-audience=weave-backend"
+})
+@AutoConfigureMockMvc
+class FirstPartyIdentityContractTest {
+
+    private static final String REQUIRED_AUDIENCE = "weave-backend";
+    private static final String FIRST_PARTY_CLIENT_ID = "com.massimotter.weave";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JwtDecoder jwtDecoder;
+
+    @BeforeEach
+    void configureJwtDecoder() {
+        given(jwtDecoder.decode(anyString())).willAnswer(invocation -> decode(invocation.getArgument(0)));
+    }
+
+    @Test
+    void acceptsTokenWithRequiredAudience() throws Exception {
+        mockMvc.perform(get("/api/v1/workspace/capabilities")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer correct-audience"))
+                .andExpect(status().isOk());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"wrong-audience", "missing-audience"})
+    void rejectsTokensWithoutRequiredAudience(String tokenValue) throws Exception {
+        mockMvc.perform(get("/api/v1/workspace/capabilities")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + tokenValue))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void rejectsTokenWithoutWorkspaceScope() throws Exception {
+        mockMvc.perform(get("/api/v1/workspace/capabilities")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer missing-scope"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void acceptsValidFullFirstPartyToken() throws Exception {
+        mockMvc.perform(get("/api/v1/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer valid-full-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.sub").value("user-123"))
+                .andExpect(jsonPath("$.preferredUsername").value("alice"))
+                .andExpect(jsonPath("$.issuedFor").value(FIRST_PARTY_CLIENT_ID))
+                .andExpect(jsonPath("$.audience[0]").value(REQUIRED_AUDIENCE))
+                .andExpect(jsonPath("$.realmRoles[0]").value("member"));
+    }
+
+    private Jwt decode(String tokenValue) {
+        Jwt jwt = switch (tokenValue) {
+            case "correct-audience" -> jwt(tokenValue, List.of(REQUIRED_AUDIENCE), "weave:workspace", null);
+            case "wrong-audience" -> jwt(tokenValue, List.of("other-api"), "weave:workspace", null);
+            case "missing-audience" -> jwt(tokenValue, null, "weave:workspace", null);
+            case "missing-scope" -> jwt(tokenValue, List.of(REQUIRED_AUDIENCE), "openid profile", null);
+            case "valid-full-token" -> jwt(tokenValue, List.of(REQUIRED_AUDIENCE), "openid profile weave:workspace",
+                    Map.of(
+                            "preferred_username", "alice",
+                            "name", "Alice Example",
+                            "email", "alice@example.com",
+                            "azp", FIRST_PARTY_CLIENT_ID,
+                            "client_id", FIRST_PARTY_CLIENT_ID,
+                            "realm_access", Map.of("roles", List.of("member"))));
+            default -> throw new JwtException("Unknown test token.");
+        };
+
+        OAuth2TokenValidatorResult audienceValidation =
+                JwtDecoderConfig.requiredAudienceValidator(REQUIRED_AUDIENCE).validate(jwt);
+        if (audienceValidation.hasErrors()) {
+            throw new JwtValidationException("JWT missing required audience.", audienceValidation.getErrors());
+        }
+
+        return jwt;
+    }
+
+    private Jwt jwt(String tokenValue, List<String> audience, String scope, Map<String, Object> claims) {
+        Instant now = Instant.parse("2026-04-18T12:00:00Z");
+        Jwt.Builder builder = Jwt.withTokenValue(tokenValue)
+                .header("alg", "none")
+                .issuer("https://auth.example.invalid/realms/weave")
+                .subject("user-123")
+                .issuedAt(now)
+                .expiresAt(now.plusSeconds(300))
+                .claim("scope", scope);
+
+        if (audience != null) {
+            builder.audience(audience);
+        }
+        if (claims != null) {
+            claims.forEach(builder::claim);
+        }
+
+        return builder.build();
+    }
+}

--- a/src/test/java/com/massimotter/weave/backend/controller/IdentityControllerTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/IdentityControllerTest.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -39,7 +40,8 @@ class IdentityControllerTest {
                         .claim("azp", "weave-app")
                         .claim("aud", List.of("weave-app", "account"))
                         .claim("realm_access", Map.of("roles", List.of("member", "admin")))
-                        .claim("groups", List.of("team-alpha", "team-beta")))))
+                        .claim("groups", List.of("team-alpha", "team-beta")))
+                        .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.sub").value("user-123"))
                 .andExpect(jsonPath("$.preferredUsername").value("alice"))

--- a/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -29,7 +30,8 @@ class WorkspaceControllerTest {
 
     @Test
     void returnsStaticWorkspaceCapabilities() throws Exception {
-        mockMvc.perform(get("/api/v1/workspace/capabilities").with(jwt()))
+        mockMvc.perform(get("/api/v1/workspace/capabilities").with(jwt()
+                        .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.shellAccess.enabled").value(true))
                 .andExpect(jsonPath("$.shellAccess.readiness").value("ready"))


### PR DESCRIPTION
Closes #4

## Changes
- Audience validation: if `WEAVE_OIDC_REQUIRED_AUDIENCE` is set, tokens without matching `aud` claim → 401
- Scope enforcement: all `/api/v1/` endpoints require scope `weave:workspace` → 403 if missing
- `azp` caller binding documented in `SecurityConfig` comments
- `application.yml` updated with full config docs
- New test: `FirstPartyIdentityContractTest` covers all token scenarios

## Test
`./gradlew test` — all green