### PR TITLE
fix(auth): validate Weave app e2e tokens

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.gitignore
+.gradle
+build
+README.md
+docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM eclipse-temurin:17-jdk-jammy AS build
+WORKDIR /workspace
+
+COPY gradlew gradlew.bat build.gradle settings.gradle ./
+COPY gradle ./gradle
+RUN chmod +x ./gradlew
+
+COPY src ./src
+RUN ./gradlew --no-daemon bootJar
+
+FROM eclipse-temurin:17-jre-jammy
+WORKDIR /app
+
+COPY --from=build /workspace/build/libs/*.jar /app/app.jar
+
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ docker run --rm \
   ./gradlew test
 ```
 
+To build the local backend image used by `weave-infra` integration runs:
+
+```bash
+docker build -t weave-backend:e2e .
+```
+
+This Dockerfile-based path is the reproducible local image build for Apple Silicon and other non-x86 hosts.
+
 ## Architecture alignment
 
 See [docs/architecture-alignment.md](/Users/flotterotter/code/weave-backend/docs/architecture-alignment.md) and the issue drafts under [docs/issues](/Users/flotterotter/code/weave-backend/docs/issues).

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This repository now starts as a JWT-protected Spring Boot API with:
 - a `/api/v1/workspace/capabilities` endpoint for the first backend-owned client contract
 - OpenAPI JSON published at `/v3/api-docs`
 - actuator health and info endpoints
-- optional audience validation for JWTs
+- first-party JWT issuer, audience, client, and workspace-scope validation
 - Gradle wrapper and GitHub Actions CI
 - issue-ready alignment drafts for `weave`, `weave-inf`, and `weave-backend`
 
@@ -33,12 +33,21 @@ The backend should not, by default:
 
 Required runtime variables:
 
-- `WEAVE_OIDC_ISSUER_URI`: issuer URI for the Keycloak realm used by Weave
+- `WEAVE_OIDC_ISSUER_URI`: public issuer URI for the Keycloak realm used by Weave
 
 Optional runtime variables:
 
-- `WEAVE_OIDC_REQUIRED_AUDIENCE`: audience to require in access tokens once `weave-inf` exposes the final audience/token-exchange contract
+- `WEAVE_OIDC_JWK_SET_URI`: internal JWKS URL for backend key discovery when it differs from the public issuer metadata route
+- `WEAVE_OIDC_REQUIRED_AUDIENCE`: audience required in access tokens, defaults to `weave-app`
+- `WEAVE_CLIENT_ID`: first-party Weave app client ID required in `azp` and/or `client_id`, defaults to `weave-app`
 - `PORT`: HTTP port, defaults to `8080`
+
+Local first-party token contract:
+
+- `iss` must match `WEAVE_OIDC_ISSUER_URI`.
+- `aud` must include `weave-app` unless `WEAVE_OIDC_REQUIRED_AUDIENCE` overrides it.
+- `azp` and/or `client_id` must be present and must match `weave-app` unless `WEAVE_CLIENT_ID` overrides it.
+- `scope` must include `weave:workspace` for `/api/v1/**`.
 
 ## Local validation
 

--- a/src/main/java/com/massimotter/weave/backend/config/JwtDecoderConfig.java
+++ b/src/main/java/com/massimotter/weave/backend/config/JwtDecoderConfig.java
@@ -1,6 +1,8 @@
 package com.massimotter.weave.backend.config;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,6 +13,7 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.util.StringUtils;
 
 @Configuration
 public class JwtDecoderConfig {
@@ -20,13 +23,21 @@ public class JwtDecoderConfig {
             OAuth2ResourceServerProperties resourceServerProperties,
             WeaveSecurityProperties weaveSecurityProperties) {
         String issuerUri = resourceServerProperties.getJwt().getIssuerUri();
-        NimbusJwtDecoder jwtDecoder = NimbusJwtDecoder.withIssuerLocation(issuerUri).build();
+        String jwkSetUri = resourceServerProperties.getJwt().getJwkSetUri();
+        NimbusJwtDecoder jwtDecoder = StringUtils.hasText(jwkSetUri)
+                ? NimbusJwtDecoder.withJwkSetUri(jwkSetUri).build()
+                : NimbusJwtDecoder.withIssuerLocation(issuerUri).build();
 
         OAuth2TokenValidator<Jwt> validator = JwtValidators.createDefaultWithIssuer(issuerUri);
         if (weaveSecurityProperties.hasRequiredAudience()) {
             validator = new DelegatingOAuth2TokenValidator<>(
                     validator,
                     requiredAudienceValidator(weaveSecurityProperties.requiredAudience()));
+        }
+        if (weaveSecurityProperties.hasRequiredAuthorizedParty()) {
+            validator = new DelegatingOAuth2TokenValidator<>(
+                    validator,
+                    requiredAuthorizedPartyValidator(weaveSecurityProperties.requiredAuthorizedParty()));
         }
 
         jwtDecoder.setJwtValidator(validator);
@@ -38,6 +49,11 @@ public class JwtDecoderConfig {
         return jwt -> hasRequiredAudience(jwt, normalizedRequiredAudience);
     }
 
+    static OAuth2TokenValidator<Jwt> requiredAuthorizedPartyValidator(String requiredAuthorizedParty) {
+        String normalizedRequiredAuthorizedParty = requiredAuthorizedParty.trim();
+        return jwt -> hasRequiredAuthorizedParty(jwt, normalizedRequiredAuthorizedParty);
+    }
+
     private static OAuth2TokenValidatorResult hasRequiredAudience(Jwt jwt, String requiredAudience) {
         List<String> audiences = jwt.getAudience();
         if (audiences != null && audiences.contains(requiredAudience)) {
@@ -47,6 +63,33 @@ public class JwtDecoderConfig {
         return OAuth2TokenValidatorResult.failure(
                 error("invalid_token",
                         "The token is missing the required audience '" + requiredAudience + "'."));
+    }
+
+    private static OAuth2TokenValidatorResult hasRequiredAuthorizedParty(Jwt jwt, String requiredAuthorizedParty) {
+        List<String> authorizedPartyClaims = Stream.of(
+                        jwt.getClaimAsString("azp"),
+                        jwt.getClaimAsString("client_id"))
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(StringUtils::hasText)
+                .toList();
+
+        if (authorizedPartyClaims.isEmpty()) {
+            return OAuth2TokenValidatorResult.failure(
+                    error("invalid_token",
+                            "The token is missing required authorized party/client ID '"
+                                    + requiredAuthorizedParty + "'."));
+        }
+
+        boolean allClaimsMatch = authorizedPartyClaims.stream()
+                .allMatch(requiredAuthorizedParty::equals);
+        if (allClaimsMatch) {
+            return OAuth2TokenValidatorResult.success();
+        }
+
+        return OAuth2TokenValidatorResult.failure(
+                error("invalid_token",
+                        "The token authorized party/client ID must be '" + requiredAuthorizedParty + "'."));
     }
 
     private static org.springframework.security.oauth2.core.OAuth2Error error(String code, String description) {

--- a/src/main/java/com/massimotter/weave/backend/config/SecurityConfig.java
+++ b/src/main/java/com/massimotter/weave/backend/config/SecurityConfig.java
@@ -45,10 +45,9 @@ public class SecurityConfig {
     @Bean
     Converter<Jwt, ? extends AbstractAuthenticationToken> jwtAuthenticationConverter() {
         JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
-        // First-party caller binding is carried by Keycloak as azp/client_id
-        // for the Flutter client com.massimotter.weave. Do not treat that
-        // claim as an authority; issuer/audience validation establishes the
-        // token contract and scopes grant API access.
+        // First-party caller binding is carried by Keycloak as azp/client_id.
+        // Do not treat that claim as an authority; issuer/audience/client
+        // validation establishes the token contract and scopes grant API access.
         converter.setJwtGrantedAuthoritiesConverter(this::extractAuthorities);
         return converter;
     }

--- a/src/main/java/com/massimotter/weave/backend/config/WeaveSecurityProperties.java
+++ b/src/main/java/com/massimotter/weave/backend/config/WeaveSecurityProperties.java
@@ -3,9 +3,31 @@ package com.massimotter.weave.backend.config;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "weave.security")
-public record WeaveSecurityProperties(String requiredAudience) {
+public record WeaveSecurityProperties(String requiredAudience, String clientId) {
+
+    private static final String DEFAULT_FIRST_PARTY_CLIENT_ID = "weave-app";
+
+    public WeaveSecurityProperties {
+        requiredAudience = defaultIfBlank(requiredAudience);
+        clientId = defaultIfBlank(clientId);
+    }
 
     public boolean hasRequiredAudience() {
         return requiredAudience != null && !requiredAudience.isBlank();
+    }
+
+    public String requiredAuthorizedParty() {
+        return clientId;
+    }
+
+    public boolean hasRequiredAuthorizedParty() {
+        return clientId != null && !clientId.isBlank();
+    }
+
+    private static String defaultIfBlank(String value) {
+        if (value == null || value.isBlank()) {
+            return DEFAULT_FIRST_PARTY_CLIENT_ID;
+        }
+        return value.trim();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,9 @@ spring:
           # Required. Keycloak realm issuer used to validate JWT iss, exp, nbf, and signature.
           # Example: https://auth.example.com/realms/weave
           issuer-uri: ${WEAVE_OIDC_ISSUER_URI}
+          # Optional. Use when the backend must fetch signing keys through an internal/private route
+          # while preserving the public issuer URI in token validation.
+          jwk-set-uri: ${WEAVE_OIDC_JWK_SET_URI:}
 
 management:
   endpoints:
@@ -24,6 +27,7 @@ management:
 
 weave:
   security:
-    # Optional. When set, JWT aud must include this backend audience or the request is rejected with 401.
-    # Leave empty only for local bootstrap environments before the Keycloak audience mapper is in place.
-    required-audience: ${WEAVE_OIDC_REQUIRED_AUDIENCE:}
+    # JWT aud must include the first-party Weave app audience.
+    required-audience: ${WEAVE_OIDC_REQUIRED_AUDIENCE:weave-app}
+    # JWT azp and/or client_id must identify the first-party Weave app client.
+    client-id: ${WEAVE_CLIENT_ID:weave-app}

--- a/src/test/java/com/massimotter/weave/backend/config/FirstPartyIdentityContractTest.java
+++ b/src/test/java/com/massimotter/weave/backend/config/FirstPartyIdentityContractTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
@@ -27,13 +28,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest(properties = {
         "spring.security.oauth2.resourceserver.jwt.issuer-uri=https://auth.example.invalid/realms/weave",
-        "weave.security.required-audience=weave-backend"
+        "weave.security.required-audience=weave-app",
+        "weave.security.client-id=weave-app"
 })
 @AutoConfigureMockMvc
 class FirstPartyIdentityContractTest {
 
-    private static final String REQUIRED_AUDIENCE = "weave-backend";
-    private static final String FIRST_PARTY_CLIENT_ID = "com.massimotter.weave";
+    private static final String REQUIRED_AUDIENCE = "weave-app";
+    private static final String FIRST_PARTY_CLIENT_ID = "weave-app";
 
     @Autowired
     private MockMvc mockMvc;
@@ -47,9 +49,9 @@ class FirstPartyIdentityContractTest {
     }
 
     @Test
-    void acceptsTokenWithRequiredAudience() throws Exception {
+    void acceptsTokenWithFirstPartyContractAndWorkspaceScope() throws Exception {
         mockMvc.perform(get("/api/v1/workspace/capabilities")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer correct-audience"))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer valid-contract"))
                 .andExpect(status().isOk());
     }
 
@@ -68,6 +70,26 @@ class FirstPartyIdentityContractTest {
                 .andExpect(status().isForbidden());
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "missing-authorized-party",
+            "wrong-azp",
+            "wrong-client-id",
+            "conflicting-authorized-party"
+    })
+    void rejectsTokensWithoutRequiredAuthorizedParty(String tokenValue) throws Exception {
+        mockMvc.perform(get("/api/v1/workspace/capabilities")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + tokenValue))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void acceptsClientIdClaimWhenAzpIsAbsent() throws Exception {
+        mockMvc.perform(get("/api/v1/workspace/capabilities")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer client-id-only"))
+                .andExpect(status().isOk());
+    }
+
     @Test
     void acceptsValidFullFirstPartyToken() throws Exception {
         mockMvc.perform(get("/api/v1/me")
@@ -82,10 +104,23 @@ class FirstPartyIdentityContractTest {
 
     private Jwt decode(String tokenValue) {
         Jwt jwt = switch (tokenValue) {
-            case "correct-audience" -> jwt(tokenValue, List.of(REQUIRED_AUDIENCE), "weave:workspace", null);
-            case "wrong-audience" -> jwt(tokenValue, List.of("other-api"), "weave:workspace", null);
-            case "missing-audience" -> jwt(tokenValue, null, "weave:workspace", null);
-            case "missing-scope" -> jwt(tokenValue, List.of(REQUIRED_AUDIENCE), "openid profile", null);
+            case "valid-contract" -> jwt(tokenValue, List.of(REQUIRED_AUDIENCE), "weave:workspace",
+                    Map.of("azp", FIRST_PARTY_CLIENT_ID));
+            case "client-id-only" -> jwt(tokenValue, List.of(REQUIRED_AUDIENCE), "weave:workspace",
+                    Map.of("client_id", FIRST_PARTY_CLIENT_ID));
+            case "wrong-audience" -> jwt(tokenValue, List.of("other-api"), "weave:workspace",
+                    Map.of("azp", FIRST_PARTY_CLIENT_ID));
+            case "missing-audience" -> jwt(tokenValue, null, "weave:workspace",
+                    Map.of("azp", FIRST_PARTY_CLIENT_ID));
+            case "missing-scope" -> jwt(tokenValue, List.of(REQUIRED_AUDIENCE), "openid profile",
+                    Map.of("azp", FIRST_PARTY_CLIENT_ID));
+            case "missing-authorized-party" -> jwt(tokenValue, List.of(REQUIRED_AUDIENCE), "weave:workspace", null);
+            case "wrong-azp" -> jwt(tokenValue, List.of(REQUIRED_AUDIENCE), "weave:workspace",
+                    Map.of("azp", "other-client"));
+            case "wrong-client-id" -> jwt(tokenValue, List.of(REQUIRED_AUDIENCE), "weave:workspace",
+                    Map.of("client_id", "other-client"));
+            case "conflicting-authorized-party" -> jwt(tokenValue, List.of(REQUIRED_AUDIENCE), "weave:workspace",
+                    Map.of("azp", FIRST_PARTY_CLIENT_ID, "client_id", "other-client"));
             case "valid-full-token" -> jwt(tokenValue, List.of(REQUIRED_AUDIENCE), "openid profile weave:workspace",
                     Map.of(
                             "preferred_username", "alice",
@@ -97,10 +132,13 @@ class FirstPartyIdentityContractTest {
             default -> throw new JwtException("Unknown test token.");
         };
 
-        OAuth2TokenValidatorResult audienceValidation =
-                JwtDecoderConfig.requiredAudienceValidator(REQUIRED_AUDIENCE).validate(jwt);
-        if (audienceValidation.hasErrors()) {
-            throw new JwtValidationException("JWT missing required audience.", audienceValidation.getErrors());
+        OAuth2TokenValidator<Jwt> validator = new org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator<>(
+                JwtDecoderConfig.requiredAudienceValidator(REQUIRED_AUDIENCE),
+                JwtDecoderConfig.requiredAuthorizedPartyValidator(FIRST_PARTY_CLIENT_ID));
+        OAuth2TokenValidatorResult validation = validator.validate(jwt);
+        if (validation.hasErrors()) {
+            throw new JwtValidationException("JWT does not satisfy the first-party contract.",
+                    validation.getErrors());
         }
 
         return jwt;

--- a/src/test/java/com/massimotter/weave/backend/config/JwtDecoderConfigTest.java
+++ b/src/test/java/com/massimotter/weave/backend/config/JwtDecoderConfigTest.java
@@ -1,0 +1,128 @@
+package com.massimotter.weave.backend.config;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtValidationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class JwtDecoderConfigTest {
+
+    private static final String ISSUER_URI = "https://auth.example.invalid/realms/weave";
+
+    @Test
+    void usesConfiguredJwkSetUriAndValidatesPublicIssuer() throws Exception {
+        RSAKey signingKey = rsaSigningKey();
+        try (JwksServer jwksServer = JwksServer.start(signingKey)) {
+            JwtDecoder jwtDecoder = jwtDecoder(jwksServer.jwkSetUri());
+
+            Jwt jwt = jwtDecoder.decode(signedToken(signingKey, ISSUER_URI));
+
+            assertThat(jwt.getIssuer()).hasToString(ISSUER_URI);
+        }
+    }
+
+    @Test
+    void rejectsWrongIssuerWhenConfiguredWithJwkSetUri() throws Exception {
+        RSAKey signingKey = rsaSigningKey();
+        try (JwksServer jwksServer = JwksServer.start(signingKey)) {
+            JwtDecoder jwtDecoder = jwtDecoder(jwksServer.jwkSetUri());
+
+            assertThrows(JwtValidationException.class,
+                    () -> jwtDecoder.decode(signedToken(signingKey, "https://wrong.example.invalid/realms/weave")));
+        }
+    }
+
+    private JwtDecoder jwtDecoder(String jwkSetUri) {
+        OAuth2ResourceServerProperties properties = new OAuth2ResourceServerProperties();
+        properties.getJwt().setIssuerUri(ISSUER_URI);
+        properties.getJwt().setJwkSetUri(jwkSetUri);
+        return new JwtDecoderConfig().jwtDecoder(properties, new WeaveSecurityProperties(null, null));
+    }
+
+    private static RSAKey rsaSigningKey() throws Exception {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(2048);
+        KeyPair keyPair = keyPairGenerator.generateKeyPair();
+        return new RSAKey.Builder((RSAPublicKey) keyPair.getPublic())
+                .privateKey((RSAPrivateKey) keyPair.getPrivate())
+                .keyID("test-key")
+                .build();
+    }
+
+    private static String signedToken(RSAKey signingKey, String issuerUri) throws Exception {
+        Instant now = Instant.now();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(issuerUri)
+                .subject("user-123")
+                .audience(List.of("weave-app"))
+                .claim("azp", "weave-app")
+                .claim("scope", "weave:workspace")
+                .issueTime(Date.from(now))
+                .notBeforeTime(Date.from(now.minusSeconds(30)))
+                .expirationTime(Date.from(now.plusSeconds(300)))
+                .build();
+        SignedJWT jwt = new SignedJWT(
+                new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(signingKey.getKeyID()).build(),
+                claims);
+        JWSSigner signer = new RSASSASigner(signingKey);
+        jwt.sign(signer);
+        return jwt.serialize();
+    }
+
+    private static final class JwksServer implements AutoCloseable {
+
+        private final HttpServer server;
+
+        private JwksServer(HttpServer server) {
+            this.server = server;
+        }
+
+        static JwksServer start(RSAKey signingKey) throws IOException {
+            String jwksJson = new JWKSet(signingKey.toPublicJWK()).toString();
+            HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            server.createContext("/jwks", exchange -> {
+                byte[] response = jwksJson.getBytes(StandardCharsets.UTF_8);
+                exchange.getResponseHeaders().set("Content-Type", "application/json");
+                exchange.sendResponseHeaders(200, response.length);
+                try (OutputStream body = exchange.getResponseBody()) {
+                    body.write(response);
+                }
+            });
+            server.start();
+            return new JwksServer(server);
+        }
+
+        String jwkSetUri() {
+            return "http://127.0.0.1:" + server.getAddress().getPort() + "/jwks";
+        }
+
+        @Override
+        public void close() {
+            server.stop(0);
+        }
+    }
+}

--- a/src/test/java/com/massimotter/weave/backend/controller/IdentityControllerTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/IdentityControllerTest.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -17,7 +18,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(controllers = IdentityController.class)
+@WebMvcTest(
+        controllers = IdentityController.class,
+        excludeAutoConfiguration = OAuth2ResourceServerAutoConfiguration.class)
 @Import(SecurityConfig.class)
 @org.springframework.test.context.TestPropertySource(properties = {
         "spring.security.oauth2.resourceserver.jwt.issuer-uri=https://auth.example.invalid/realms/weave"

--- a/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
@@ -3,6 +3,7 @@ package com.massimotter.weave.backend.controller;
 import com.massimotter.weave.backend.config.SecurityConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -15,7 +16,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(controllers = WorkspaceController.class)
+@WebMvcTest(
+        controllers = WorkspaceController.class,
+        excludeAutoConfiguration = OAuth2ResourceServerAutoConfiguration.class)
 @Import(SecurityConfig.class)
 @org.springframework.test.context.TestPropertySource(properties = {
         "spring.security.oauth2.resourceserver.jwt.issuer-uri=https://auth.example.invalid/realms/weave"


### PR DESCRIPTION
Closes masssi164/weave#32

Backend side changes:
- add optional internal JWKS lookup while preserving public issuer validation
- require aud=weave-app by default and require azp/client_id to match WEAVE_CLIENT_ID
- keep weave:workspace authority enforcement for /api/v1/**
- update auth contract tests and README configuration docs

Validation:
- ./gradlew test could not run directly because this machine has no Java runtime installed
- docker run --rm -u "$(id -u):$(id -g)" -e HOME=/tmp -e GRADLE_USER_HOME=/tmp/.gradle -v /tmp/weave-gradle-cache:/tmp/.gradle -v "$PWD:/workspace" -w /workspace eclipse-temurin:17-jdk ./gradlew test --rerun-tasks passed