### PR TITLE
chore(api): document release behavior and auth error contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Optional runtime variables:
 - `WEAVE_CLIENT_ID`: first-party Weave app client ID required in `azp` and/or `client_id`, defaults to `weave-app`
 - `PORT`: HTTP port, defaults to `8080`
 
+See [docs/release-operations.md](docs/release-operations.md) for the Release 1 runtime contract, stable error envelope, and minimum operator checks.
+
 Local first-party token contract:
 
 - `iss` must match `WEAVE_OIDC_ISSUER_URI`.
@@ -77,6 +79,13 @@ docker build -t weave-backend:e2e .
 ```
 
 This Dockerfile-based path is the reproducible local image build for Apple Silicon and other non-x86 hosts.
+
+## Release-grade API behavior
+
+- `/api/v1/**` returns structured JSON for `401` and `403` responses.
+- `401` means the bearer token is missing or fails the first-party Weave token contract.
+- `403` means the caller is authenticated but lacks the `weave:workspace` scope.
+- `/v3/api-docs` publishes the same error schema so app and operator tooling can rely on it.
 
 ## Architecture alignment
 

--- a/docs/release-operations.md
+++ b/docs/release-operations.md
@@ -1,0 +1,63 @@
+# Release 1 API operations guide
+
+This backend is intentionally small for Release 1, but operators still need a clear runtime contract.
+
+## Runtime inputs
+
+Required:
+
+- `WEAVE_OIDC_ISSUER_URI`: public issuer URI for the Keycloak realm used by Weave
+
+Optional:
+
+- `WEAVE_OIDC_JWK_SET_URI`: internal JWKS URL when the backend cannot use the issuer metadata endpoint directly
+- `WEAVE_OIDC_REQUIRED_AUDIENCE`: required audience in Weave access tokens, defaults to `weave-app`
+- `WEAVE_CLIENT_ID`: required first-party client identifier in `azp` and/or `client_id`, defaults to `weave-app`
+- `PORT`: HTTP listen port, defaults to `8080`
+
+## Protected API behavior
+
+All `/api/v1/**` routes require a bearer token that satisfies the first-party Weave contract:
+
+- `iss` matches `WEAVE_OIDC_ISSUER_URI`
+- `aud` includes `WEAVE_OIDC_REQUIRED_AUDIENCE`
+- `azp` and/or `client_id` matches `WEAVE_CLIENT_ID`
+- `scope` includes `weave:workspace`
+
+Protected endpoints return a stable JSON error envelope on auth failures:
+
+```json
+{
+  "timestamp": "2026-04-20T11:32:15.123Z",
+  "status": 401,
+  "error": "Unauthorized",
+  "message": "Bearer authentication is required and must satisfy the first-party Weave token contract.",
+  "path": "/api/v1/workspace/capabilities"
+}
+```
+
+Use `401` for missing or invalid tokens. Use `403` when the token is authenticated but does not include `weave:workspace`.
+
+## Minimum operator checks
+
+- `GET /actuator/health` should return `200 OK`
+- `GET /v3/api-docs` should return the published OpenAPI document
+- `GET /api/v1/me` with a valid first-party token should return caller claims
+- `GET /api/v1/workspace/capabilities` with a valid first-party token should return Release 1 readiness data
+
+## Logging and audit baseline
+
+For Release 1, keep at least:
+
+- reverse proxy access logs with request path, status, latency, and request id
+- application logs from stdout/stderr collected by the deployment target
+- retained auth failure logs long enough to diagnose issuer, audience, or scope drift
+
+Do not log raw bearer tokens.
+
+## Deployment expectations
+
+- Run behind TLS termination
+- Keep the backend on an internal/private port when a reverse proxy is present
+- Keep issuer and JWKS URLs aligned with the public auth contract exposed to the app
+- Treat issuer, JWKS, and client/audience values as release contract, not per-developer convenience settings

--- a/src/main/java/com/massimotter/weave/backend/config/ApiAccessDeniedHandler.java
+++ b/src/main/java/com/massimotter/weave/backend/config/ApiAccessDeniedHandler.java
@@ -1,0 +1,30 @@
+package com.massimotter.weave.backend.config;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ApiAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ApiErrorResponseWriter errorResponseWriter;
+
+    public ApiAccessDeniedHandler(ApiErrorResponseWriter errorResponseWriter) {
+        this.errorResponseWriter = errorResponseWriter;
+    }
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+            AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        errorResponseWriter.write(
+                request,
+                response,
+                HttpStatus.FORBIDDEN,
+                "The bearer token is authenticated but missing the required weave:workspace scope.");
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/config/ApiAuthenticationEntryPoint.java
+++ b/src/main/java/com/massimotter/weave/backend/config/ApiAuthenticationEntryPoint.java
@@ -1,0 +1,30 @@
+package com.massimotter.weave.backend.config;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ApiAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ApiErrorResponseWriter errorResponseWriter;
+
+    public ApiAuthenticationEntryPoint(ApiErrorResponseWriter errorResponseWriter) {
+        this.errorResponseWriter = errorResponseWriter;
+    }
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+            AuthenticationException authException) throws IOException, ServletException {
+        errorResponseWriter.write(
+                request,
+                response,
+                HttpStatus.UNAUTHORIZED,
+                "Bearer authentication is required and must satisfy the first-party Weave token contract.");
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/config/ApiErrorResponseWriter.java
+++ b/src/main/java/com/massimotter/weave/backend/config/ApiErrorResponseWriter.java
@@ -1,0 +1,34 @@
+package com.massimotter.weave.backend.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.massimotter.weave.backend.model.ApiErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.Instant;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ApiErrorResponseWriter {
+
+    private final ObjectMapper objectMapper;
+
+    public ApiErrorResponseWriter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public void write(HttpServletRequest request, HttpServletResponse response, HttpStatus status, String message)
+            throws IOException {
+        response.setStatus(status.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(response.getWriter(), new ApiErrorResponse(
+                Instant.now().toString(),
+                status.value(),
+                status.getReasonPhrase(),
+                message,
+                request.getRequestURI()));
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/config/OpenApiConfig.java
+++ b/src/main/java/com/massimotter/weave/backend/config/OpenApiConfig.java
@@ -3,7 +3,12 @@ package com.massimotter.weave.backend.config;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.responses.ApiResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -18,6 +23,15 @@ public class OpenApiConfig {
     @Bean
     OpenAPI weaveOpenApi() {
         return new OpenAPI()
+                .components(new Components()
+                        .addResponses("UnauthorizedError", new ApiResponse()
+                                .description("Missing or invalid bearer token.")
+                                .content(new Content().addMediaType("application/json",
+                                        new MediaType().schema(new Schema<>().$ref("#/components/schemas/ApiErrorResponse")))))
+                        .addResponses("ForbiddenError", new ApiResponse()
+                                .description("Bearer token is missing the weave:workspace scope.")
+                                .content(new Content().addMediaType("application/json",
+                                        new MediaType().schema(new Schema<>().$ref("#/components/schemas/ApiErrorResponse"))))))
                 .info(new Info()
                         .title("Weave Backend API")
                         .version("v1")

--- a/src/main/java/com/massimotter/weave/backend/config/SecurityConfig.java
+++ b/src/main/java/com/massimotter/weave/backend/config/SecurityConfig.java
@@ -26,18 +26,32 @@ public class SecurityConfig {
 
     private static final String WORKSPACE_SCOPE_AUTHORITY = "SCOPE_weave:workspace";
 
+    private final ApiAuthenticationEntryPoint authenticationEntryPoint;
+    private final ApiAccessDeniedHandler accessDeniedHandler;
+
+    public SecurityConfig(ApiAuthenticationEntryPoint authenticationEntryPoint,
+            ApiAccessDeniedHandler accessDeniedHandler) {
+        this.authenticationEntryPoint = authenticationEntryPoint;
+        this.accessDeniedHandler = accessDeniedHandler;
+    }
+
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(exceptions -> exceptions
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler))
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/actuator/health", "/actuator/info", "/error").permitAll()
                         .requestMatchers("/v3/api-docs", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/api/v1/**").hasAuthority(WORKSPACE_SCOPE_AUTHORITY)
                         .anyRequest().authenticated())
-                .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt ->
-                        jwt.jwtAuthenticationConverter(jwtAuthenticationConverter())));
+                .oauth2ResourceServer(oauth2 -> oauth2
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler)
+                        .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter())));
 
         return http.build();
     }

--- a/src/main/java/com/massimotter/weave/backend/controller/IdentityController.java
+++ b/src/main/java/com/massimotter/weave/backend/controller/IdentityController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import com.massimotter.weave.backend.model.AuthenticatedUserResponse;
+import com.massimotter.weave.backend.model.ApiErrorResponse;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -32,8 +33,10 @@ public class IdentityController {
                     responseCode = "200",
                     description = "Authenticated caller details.",
                     content = @Content(schema = @Schema(implementation = AuthenticatedUserResponse.class))),
-            @ApiResponse(responseCode = "401", description = "Missing or invalid bearer token."),
-            @ApiResponse(responseCode = "403", description = "Bearer token is missing the weave:workspace scope.")
+            @ApiResponse(responseCode = "401", description = "Missing or invalid bearer token.",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Bearer token is missing the weave:workspace scope.",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
     })
     public AuthenticatedUserResponse me(@AuthenticationPrincipal Jwt jwt) {
         return new AuthenticatedUserResponse(

--- a/src/main/java/com/massimotter/weave/backend/controller/WorkspaceController.java
+++ b/src/main/java/com/massimotter/weave/backend/controller/WorkspaceController.java
@@ -1,5 +1,6 @@
 package com.massimotter.weave.backend.controller;
 
+import com.massimotter.weave.backend.model.ApiErrorResponse;
 import com.massimotter.weave.backend.model.WorkspaceCapabilitiesResponse;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityStatusResponse;
@@ -29,8 +30,10 @@ public class WorkspaceController {
                     responseCode = "200",
                     description = "Workspace capability snapshot.",
                     content = @Content(schema = @Schema(implementation = WorkspaceCapabilitiesResponse.class))),
-            @ApiResponse(responseCode = "401", description = "Missing or invalid bearer token."),
-            @ApiResponse(responseCode = "403", description = "Bearer token is missing the weave:workspace scope.")
+            @ApiResponse(responseCode = "401", description = "Missing or invalid bearer token.",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Bearer token is missing the weave:workspace scope.",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
     })
     public WorkspaceCapabilitiesResponse capabilities() {
         return new WorkspaceCapabilitiesResponse(

--- a/src/main/java/com/massimotter/weave/backend/model/ApiErrorResponse.java
+++ b/src/main/java/com/massimotter/weave/backend/model/ApiErrorResponse.java
@@ -1,0 +1,17 @@
+package com.massimotter.weave.backend.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Stable JSON error envelope returned by protected API endpoints.")
+public record ApiErrorResponse(
+        @Schema(description = "UTC timestamp when the error response was generated.", example = "2026-04-20T11:32:15.123Z")
+        String timestamp,
+        @Schema(description = "HTTP status code.", example = "401")
+        int status,
+        @Schema(description = "Short error category.", example = "Unauthorized")
+        String error,
+        @Schema(description = "Operator-facing explanation of what failed.", example = "Bearer authentication is required to access this endpoint.")
+        String message,
+        @Schema(description = "Request path that produced the error.", example = "/api/v1/workspace/capabilities")
+        String path) {
+}

--- a/src/test/java/com/massimotter/weave/backend/config/FirstPartyIdentityContractTest.java
+++ b/src/test/java/com/massimotter/weave/backend/config/FirstPartyIdentityContractTest.java
@@ -21,6 +21,9 @@ import org.springframework.security.oauth2.jwt.JwtValidationException;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.not;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -60,14 +63,26 @@ class FirstPartyIdentityContractTest {
     void rejectsTokensWithoutRequiredAudience(String tokenValue) throws Exception {
         mockMvc.perform(get("/api/v1/workspace/capabilities")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + tokenValue))
-                .andExpect(status().isUnauthorized());
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.error").value("Unauthorized"))
+                .andExpect(jsonPath("$.message").value(
+                        "Bearer authentication is required and must satisfy the first-party Weave token contract."))
+                .andExpect(jsonPath("$.path").value(endsWith("/api/v1/workspace/capabilities")))
+                .andExpect(jsonPath("$.timestamp").value(not(emptyOrNullString())));
     }
 
     @Test
     void rejectsTokenWithoutWorkspaceScope() throws Exception {
         mockMvc.perform(get("/api/v1/workspace/capabilities")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer missing-scope"))
-                .andExpect(status().isForbidden());
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.status").value(403))
+                .andExpect(jsonPath("$.error").value("Forbidden"))
+                .andExpect(jsonPath("$.message").value(
+                        "The bearer token is authenticated but missing the required weave:workspace scope."))
+                .andExpect(jsonPath("$.path").value(endsWith("/api/v1/workspace/capabilities")))
+                .andExpect(jsonPath("$.timestamp").value(not(emptyOrNullString())));
     }
 
     @ParameterizedTest

--- a/src/test/java/com/massimotter/weave/backend/controller/IdentityControllerTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/IdentityControllerTest.java
@@ -1,5 +1,8 @@
 package com.massimotter.weave.backend.controller;
 
+import com.massimotter.weave.backend.config.ApiAccessDeniedHandler;
+import com.massimotter.weave.backend.config.ApiAuthenticationEntryPoint;
+import com.massimotter.weave.backend.config.ApiErrorResponseWriter;
 import com.massimotter.weave.backend.config.SecurityConfig;
 import java.util.List;
 import java.util.Map;
@@ -21,7 +24,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(
         controllers = IdentityController.class,
         excludeAutoConfiguration = OAuth2ResourceServerAutoConfiguration.class)
-@Import(SecurityConfig.class)
+@Import({SecurityConfig.class, ApiAuthenticationEntryPoint.class, ApiAccessDeniedHandler.class, ApiErrorResponseWriter.class})
 @org.springframework.test.context.TestPropertySource(properties = {
         "spring.security.oauth2.resourceserver.jwt.issuer-uri=https://auth.example.invalid/realms/weave"
 })

--- a/src/test/java/com/massimotter/weave/backend/controller/OpenApiDocumentationTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/OpenApiDocumentationTest.java
@@ -33,6 +33,9 @@ class OpenApiDocumentationTest {
                 .andExpect(jsonPath("$.info.title").value("Weave Backend API"))
                 .andExpect(jsonPath("$.paths['/api/v1/me']").exists())
                 .andExpect(jsonPath("$.paths['/api/v1/workspace/capabilities']").exists())
+                .andExpect(jsonPath("$.components.schemas.ApiErrorResponse.properties.status.type").value("integer"))
+                .andExpect(jsonPath("$.components.schemas.ApiErrorResponse.properties.message.type").value("string"))
+                .andExpect(jsonPath("$.components.responses.UnauthorizedError.description").value("Missing or invalid bearer token."))
                 .andExpect(jsonPath("$.components.securitySchemes['bearer-jwt'].type").value("http"));
     }
 }

--- a/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
@@ -1,5 +1,8 @@
 package com.massimotter.weave.backend.controller;
 
+import com.massimotter.weave.backend.config.ApiAccessDeniedHandler;
+import com.massimotter.weave.backend.config.ApiAuthenticationEntryPoint;
+import com.massimotter.weave.backend.config.ApiErrorResponseWriter;
 import com.massimotter.weave.backend.config.SecurityConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,7 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(
         controllers = WorkspaceController.class,
         excludeAutoConfiguration = OAuth2ResourceServerAutoConfiguration.class)
-@Import(SecurityConfig.class)
+@Import({SecurityConfig.class, ApiAuthenticationEntryPoint.class, ApiAccessDeniedHandler.class, ApiErrorResponseWriter.class})
 @org.springframework.test.context.TestPropertySource(properties = {
         "spring.security.oauth2.resourceserver.jwt.issuer-uri=https://auth.example.invalid/realms/weave"
 })


### PR DESCRIPTION
## Summary
- return a stable JSON error envelope for protected API auth failures
- publish the error schema in OpenAPI and document the Release 1 operator/runtime contract
- extend integration and MVC coverage for auth behavior and published docs

## Testing
- docker run --rm -u "$(id -u):$(id -g)" -e HOME=/tmp -e GRADLE_USER_HOME=/tmp/.gradle -v "$PWD:/workspace" -w /workspace eclipse-temurin:17-jdk ./gradlew test

Closes #13.
