### PR TITLE
feat(workspace): support explicit capability readiness overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,19 +42,23 @@ Optional runtime variables:
 - `WEAVE_CLIENT_ID`: first-party Weave app client ID required in `azp` and/or `client_id`, defaults to `weave-app`
 - `WEAVE_WORKSPACE_SHELL_ACCESS_ENABLED`: enable the authenticated shell contract, defaults to `true`
 - `WEAVE_WORKSPACE_CHAT_ENABLED`: enable chat in the workspace snapshot, defaults to `true`
-- `WEAVE_MATRIX_HOMESERVER_URL`: public Matrix base URL used as the chat readiness source of truth
+- `WEAVE_MATRIX_HOMESERVER_URL`: public Matrix base URL used by chat auto-readiness
+- `WEAVE_WORKSPACE_CHAT_READINESS`: optional explicit chat readiness override (`ready`, `degraded`, `blocked`, `unavailable`)
 - `WEAVE_WORKSPACE_FILES_ENABLED`: enable files in the workspace snapshot, defaults to `true`
-- `WEAVE_NEXTCLOUD_BASE_URL`: public Nextcloud base URL used as the files readiness source of truth
+- `WEAVE_NEXTCLOUD_BASE_URL`: public Nextcloud base URL used by files auto-readiness
+- `WEAVE_WORKSPACE_FILES_READINESS`: optional explicit files readiness override (`ready`, `degraded`, `blocked`, `unavailable`)
 - `WEAVE_WORKSPACE_CALENDAR_ENABLED`: enable the calendar capability, defaults to `false`
+- `WEAVE_WORKSPACE_CALENDAR_READINESS`: optional explicit calendar readiness override (`ready`, `degraded`, `blocked`, `unavailable`)
 - `WEAVE_WORKSPACE_BOARDS_ENABLED`: enable the boards capability, defaults to `false`
+- `WEAVE_WORKSPACE_BOARDS_READINESS`: optional explicit boards readiness override (`ready`, `degraded`, `blocked`, `unavailable`)
 - `PORT`: HTTP port, defaults to `8080`
 
 Workspace capability source of truth:
 
-- `shellAccess` is `ready` only when JWT validation can be enforced with a configured issuer, audience, and first-party client contract.
-- `chat` is configuration-backed. It is `ready` when enabled and `WEAVE_MATRIX_HOMESERVER_URL` is configured, `degraded` when enabled without that route, and `blocked` if shell access itself is blocked.
-- `files` is configuration-backed. It is `ready` when enabled and `WEAVE_NEXTCLOUD_BASE_URL` is configured, `degraded` when enabled without that route, and `blocked` if shell access itself is blocked.
-- `calendar` and `boards` stay contract-stable but `unavailable` by default until the workspace explicitly enables them.
+- `shellAccess` is `unavailable` when disabled, otherwise `ready` only when JWT validation can be enforced with a configured issuer, audience, and first-party client contract.
+- `chat` is configuration-backed. When enabled it follows `WEAVE_WORKSPACE_CHAT_READINESS` if set, otherwise it is `ready` when `WEAVE_MATRIX_HOMESERVER_URL` is configured, `degraded` without that route, and `blocked` if the shell contract itself is blocked.
+- `files` is configuration-backed. When enabled it follows `WEAVE_WORKSPACE_FILES_READINESS` if set, otherwise it is `ready` when `WEAVE_NEXTCLOUD_BASE_URL` is configured, `degraded` without that route, and `blocked` if the shell contract itself is blocked.
+- `calendar` and `boards` stay contract-stable. They are `unavailable` when disabled, and can intentionally advertise another readiness via their explicit override variables when the workspace wants to surface rollout state.
 
 Local first-party token contract:
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,21 @@ Optional runtime variables:
 - `WEAVE_OIDC_JWK_SET_URI`: internal JWKS URL for backend key discovery when it differs from the public issuer metadata route
 - `WEAVE_OIDC_REQUIRED_AUDIENCE`: audience required in access tokens, defaults to `weave-app`
 - `WEAVE_CLIENT_ID`: first-party Weave app client ID required in `azp` and/or `client_id`, defaults to `weave-app`
+- `WEAVE_WORKSPACE_SHELL_ACCESS_ENABLED`: enable the authenticated shell contract, defaults to `true`
+- `WEAVE_WORKSPACE_CHAT_ENABLED`: enable chat in the workspace snapshot, defaults to `true`
+- `WEAVE_MATRIX_HOMESERVER_URL`: public Matrix base URL used as the chat readiness source of truth
+- `WEAVE_WORKSPACE_FILES_ENABLED`: enable files in the workspace snapshot, defaults to `true`
+- `WEAVE_NEXTCLOUD_BASE_URL`: public Nextcloud base URL used as the files readiness source of truth
+- `WEAVE_WORKSPACE_CALENDAR_ENABLED`: enable the calendar capability, defaults to `false`
+- `WEAVE_WORKSPACE_BOARDS_ENABLED`: enable the boards capability, defaults to `false`
 - `PORT`: HTTP port, defaults to `8080`
+
+Workspace capability source of truth:
+
+- `shellAccess` is `ready` only when JWT validation can be enforced with a configured issuer, audience, and first-party client contract.
+- `chat` is configuration-backed. It is `ready` when enabled and `WEAVE_MATRIX_HOMESERVER_URL` is configured, `degraded` when enabled without that route, and `blocked` if shell access itself is blocked.
+- `files` is configuration-backed. It is `ready` when enabled and `WEAVE_NEXTCLOUD_BASE_URL` is configured, `degraded` when enabled without that route, and `blocked` if shell access itself is blocked.
+- `calendar` and `boards` stay contract-stable but `unavailable` by default until the workspace explicitly enables them.
 
 Local first-party token contract:
 

--- a/src/main/java/com/massimotter/weave/backend/WeaveBackendApplication.java
+++ b/src/main/java/com/massimotter/weave/backend/WeaveBackendApplication.java
@@ -1,12 +1,13 @@
 package com.massimotter.weave.backend;
 
 import com.massimotter.weave.backend.config.WeaveSecurityProperties;
+import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
-@EnableConfigurationProperties(WeaveSecurityProperties.class)
+@EnableConfigurationProperties({WeaveSecurityProperties.class, WorkspaceCapabilityProperties.class})
 public class WeaveBackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/massimotter/weave/backend/config/WorkspaceCapabilityProperties.java
+++ b/src/main/java/com/massimotter/weave/backend/config/WorkspaceCapabilityProperties.java
@@ -1,8 +1,10 @@
 package com.massimotter.weave.backend.config;
 
+import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "weave.workspace")
+
 public record WorkspaceCapabilityProperties(
         Capability shellAccess,
         Capability chat,
@@ -11,20 +13,24 @@ public record WorkspaceCapabilityProperties(
         Capability boards) {
 
     public WorkspaceCapabilityProperties {
-        shellAccess = defaultCapability(shellAccess, true, null);
-        chat = defaultCapability(chat, true, null);
-        files = defaultCapability(files, true, null);
-        calendar = defaultCapability(calendar, false, null);
-        boards = defaultCapability(boards, false, null);
+        shellAccess = defaultCapability(shellAccess, true, null, null);
+        chat = defaultCapability(chat, true, null, null);
+        files = defaultCapability(files, true, null, null);
+        calendar = defaultCapability(calendar, false, null, null);
+        boards = defaultCapability(boards, false, null, null);
     }
 
-    private static Capability defaultCapability(Capability capability, boolean enabled, String dependencyUrl) {
+    private static Capability defaultCapability(
+            Capability capability,
+            boolean enabled,
+            String dependencyUrl,
+            WorkspaceCapabilityReadiness readiness) {
         if (capability == null) {
-            return new Capability(enabled, dependencyUrl);
+            return new Capability(enabled, dependencyUrl, readiness);
         }
-        return new Capability(capability.enabled(), capability.dependencyUrl());
+        return new Capability(capability.enabled(), capability.dependencyUrl(), capability.readiness());
     }
 
-    public record Capability(boolean enabled, String dependencyUrl) {
+    public record Capability(boolean enabled, String dependencyUrl, WorkspaceCapabilityReadiness readiness) {
     }
 }

--- a/src/main/java/com/massimotter/weave/backend/config/WorkspaceCapabilityProperties.java
+++ b/src/main/java/com/massimotter/weave/backend/config/WorkspaceCapabilityProperties.java
@@ -1,0 +1,30 @@
+package com.massimotter.weave.backend.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "weave.workspace")
+public record WorkspaceCapabilityProperties(
+        Capability shellAccess,
+        Capability chat,
+        Capability files,
+        Capability calendar,
+        Capability boards) {
+
+    public WorkspaceCapabilityProperties {
+        shellAccess = defaultCapability(shellAccess, true, null);
+        chat = defaultCapability(chat, true, null);
+        files = defaultCapability(files, true, null);
+        calendar = defaultCapability(calendar, false, null);
+        boards = defaultCapability(boards, false, null);
+    }
+
+    private static Capability defaultCapability(Capability capability, boolean enabled, String dependencyUrl) {
+        if (capability == null) {
+            return new Capability(enabled, dependencyUrl);
+        }
+        return new Capability(capability.enabled(), capability.dependencyUrl());
+    }
+
+    public record Capability(boolean enabled, String dependencyUrl) {
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/controller/WorkspaceController.java
+++ b/src/main/java/com/massimotter/weave/backend/controller/WorkspaceController.java
@@ -1,8 +1,7 @@
 package com.massimotter.weave.backend.controller;
 
 import com.massimotter.weave.backend.model.WorkspaceCapabilitiesResponse;
-import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
-import com.massimotter.weave.backend.model.WorkspaceCapabilityStatusResponse;
+import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -19,6 +18,12 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Workspace", description = "Workspace readiness and capability endpoints.")
 public class WorkspaceController {
 
+    private final WorkspaceCapabilityService workspaceCapabilityService;
+
+    public WorkspaceController(WorkspaceCapabilityService workspaceCapabilityService) {
+        this.workspaceCapabilityService = workspaceCapabilityService;
+    }
+
     @GetMapping("/capabilities")
     @Operation(
             summary = "Get workspace capability readiness",
@@ -33,11 +38,6 @@ public class WorkspaceController {
             @ApiResponse(responseCode = "403", description = "Bearer token is missing the weave:workspace scope.")
     })
     public WorkspaceCapabilitiesResponse capabilities() {
-        return new WorkspaceCapabilitiesResponse(
-                new WorkspaceCapabilityStatusResponse(true, WorkspaceCapabilityReadiness.READY),
-                new WorkspaceCapabilityStatusResponse(true, WorkspaceCapabilityReadiness.READY),
-                new WorkspaceCapabilityStatusResponse(true, WorkspaceCapabilityReadiness.READY),
-                new WorkspaceCapabilityStatusResponse(false, WorkspaceCapabilityReadiness.UNAVAILABLE),
-                new WorkspaceCapabilityStatusResponse(false, WorkspaceCapabilityReadiness.UNAVAILABLE));
+        return workspaceCapabilityService.snapshot();
     }
 }

--- a/src/main/java/com/massimotter/weave/backend/service/WorkspaceCapabilityService.java
+++ b/src/main/java/com/massimotter/weave/backend/service/WorkspaceCapabilityService.java
@@ -1,0 +1,70 @@
+package com.massimotter.weave.backend.service;
+
+import com.massimotter.weave.backend.config.WeaveSecurityProperties;
+import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
+import com.massimotter.weave.backend.model.WorkspaceCapabilitiesResponse;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityStatusResponse;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
+import org.springframework.stereotype.Service;
+
+@Service
+public class WorkspaceCapabilityService {
+
+    private final OAuth2ResourceServerProperties resourceServerProperties;
+    private final WeaveSecurityProperties weaveSecurityProperties;
+    private final WorkspaceCapabilityProperties workspaceCapabilityProperties;
+
+    public WorkspaceCapabilityService(
+            OAuth2ResourceServerProperties resourceServerProperties,
+            WeaveSecurityProperties weaveSecurityProperties,
+            WorkspaceCapabilityProperties workspaceCapabilityProperties) {
+        this.resourceServerProperties = resourceServerProperties;
+        this.weaveSecurityProperties = weaveSecurityProperties;
+        this.workspaceCapabilityProperties = workspaceCapabilityProperties;
+    }
+
+    public WorkspaceCapabilitiesResponse snapshot() {
+        WorkspaceCapabilityReadiness shellAccessReadiness = shellAccessReadiness();
+        return new WorkspaceCapabilitiesResponse(
+                status(workspaceCapabilityProperties.shellAccess(), shellAccessReadiness),
+                dependentStatus(workspaceCapabilityProperties.chat(), shellAccessReadiness),
+                dependentStatus(workspaceCapabilityProperties.files(), shellAccessReadiness),
+                status(workspaceCapabilityProperties.calendar(), WorkspaceCapabilityReadiness.UNAVAILABLE),
+                status(workspaceCapabilityProperties.boards(), WorkspaceCapabilityReadiness.UNAVAILABLE));
+    }
+
+    private WorkspaceCapabilityStatusResponse dependentStatus(
+            WorkspaceCapabilityProperties.Capability capability,
+            WorkspaceCapabilityReadiness shellAccessReadiness) {
+        if (!capability.enabled()) {
+            return status(capability, WorkspaceCapabilityReadiness.UNAVAILABLE);
+        }
+        if (shellAccessReadiness == WorkspaceCapabilityReadiness.BLOCKED) {
+            return status(capability, WorkspaceCapabilityReadiness.BLOCKED);
+        }
+        if (hasText(capability.dependencyUrl())) {
+            return status(capability, WorkspaceCapabilityReadiness.READY);
+        }
+        return status(capability, WorkspaceCapabilityReadiness.DEGRADED);
+    }
+
+    private WorkspaceCapabilityReadiness shellAccessReadiness() {
+        boolean hasIssuer = hasText(resourceServerProperties.getJwt().getIssuerUri());
+        boolean hasAudience = hasText(weaveSecurityProperties.requiredAudience());
+        boolean hasClientId = hasText(weaveSecurityProperties.clientId());
+        return hasIssuer && hasAudience && hasClientId
+                ? WorkspaceCapabilityReadiness.READY
+                : WorkspaceCapabilityReadiness.BLOCKED;
+    }
+
+    private WorkspaceCapabilityStatusResponse status(
+            WorkspaceCapabilityProperties.Capability capability,
+            WorkspaceCapabilityReadiness readiness) {
+        return new WorkspaceCapabilityStatusResponse(capability.enabled(), readiness);
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/service/WorkspaceCapabilityService.java
+++ b/src/main/java/com/massimotter/weave/backend/service/WorkspaceCapabilityService.java
@@ -30,8 +30,8 @@ public class WorkspaceCapabilityService {
                 status(workspaceCapabilityProperties.shellAccess(), shellAccessReadiness),
                 dependentStatus(workspaceCapabilityProperties.chat(), shellAccessReadiness),
                 dependentStatus(workspaceCapabilityProperties.files(), shellAccessReadiness),
-                status(workspaceCapabilityProperties.calendar(), WorkspaceCapabilityReadiness.UNAVAILABLE),
-                status(workspaceCapabilityProperties.boards(), WorkspaceCapabilityReadiness.UNAVAILABLE));
+                standaloneStatus(workspaceCapabilityProperties.calendar(), WorkspaceCapabilityReadiness.UNAVAILABLE),
+                standaloneStatus(workspaceCapabilityProperties.boards(), WorkspaceCapabilityReadiness.UNAVAILABLE));
     }
 
     private WorkspaceCapabilityStatusResponse dependentStatus(
@@ -43,13 +43,31 @@ public class WorkspaceCapabilityService {
         if (shellAccessReadiness == WorkspaceCapabilityReadiness.BLOCKED) {
             return status(capability, WorkspaceCapabilityReadiness.BLOCKED);
         }
+        if (capability.readiness() != null) {
+            return status(capability, capability.readiness());
+        }
         if (hasText(capability.dependencyUrl())) {
             return status(capability, WorkspaceCapabilityReadiness.READY);
         }
         return status(capability, WorkspaceCapabilityReadiness.DEGRADED);
     }
 
+    private WorkspaceCapabilityStatusResponse standaloneStatus(
+            WorkspaceCapabilityProperties.Capability capability,
+            WorkspaceCapabilityReadiness defaultReadiness) {
+        if (!capability.enabled()) {
+            return status(capability, WorkspaceCapabilityReadiness.UNAVAILABLE);
+        }
+        if (capability.readiness() != null) {
+            return status(capability, capability.readiness());
+        }
+        return status(capability, defaultReadiness);
+    }
+
     private WorkspaceCapabilityReadiness shellAccessReadiness() {
+        if (!workspaceCapabilityProperties.shellAccess().enabled()) {
+            return WorkspaceCapabilityReadiness.UNAVAILABLE;
+        }
         boolean hasIssuer = hasText(resourceServerProperties.getJwt().getIssuerUri());
         boolean hasAudience = hasText(weaveSecurityProperties.requiredAudience());
         boolean hasClientId = hasText(weaveSecurityProperties.clientId());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,3 +31,16 @@ weave:
     required-audience: ${WEAVE_OIDC_REQUIRED_AUDIENCE:weave-app}
     # JWT azp and/or client_id must identify the first-party Weave app client.
     client-id: ${WEAVE_CLIENT_ID:weave-app}
+  workspace:
+    shell-access:
+      enabled: ${WEAVE_WORKSPACE_SHELL_ACCESS_ENABLED:true}
+    chat:
+      enabled: ${WEAVE_WORKSPACE_CHAT_ENABLED:true}
+      dependency-url: ${WEAVE_MATRIX_HOMESERVER_URL:}
+    files:
+      enabled: ${WEAVE_WORKSPACE_FILES_ENABLED:true}
+      dependency-url: ${WEAVE_NEXTCLOUD_BASE_URL:}
+    calendar:
+      enabled: ${WEAVE_WORKSPACE_CALENDAR_ENABLED:false}
+    boards:
+      enabled: ${WEAVE_WORKSPACE_BOARDS_ENABLED:false}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,10 +37,14 @@ weave:
     chat:
       enabled: ${WEAVE_WORKSPACE_CHAT_ENABLED:true}
       dependency-url: ${WEAVE_MATRIX_HOMESERVER_URL:}
+      readiness: ${WEAVE_WORKSPACE_CHAT_READINESS:}
     files:
       enabled: ${WEAVE_WORKSPACE_FILES_ENABLED:true}
       dependency-url: ${WEAVE_NEXTCLOUD_BASE_URL:}
+      readiness: ${WEAVE_WORKSPACE_FILES_READINESS:}
     calendar:
       enabled: ${WEAVE_WORKSPACE_CALENDAR_ENABLED:false}
+      readiness: ${WEAVE_WORKSPACE_CALENDAR_READINESS:}
     boards:
       enabled: ${WEAVE_WORKSPACE_BOARDS_ENABLED:false}
+      readiness: ${WEAVE_WORKSPACE_BOARDS_READINESS:}

--- a/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
@@ -1,9 +1,14 @@
 package com.massimotter.weave.backend.controller;
 
 import com.massimotter.weave.backend.config.SecurityConfig;
+import com.massimotter.weave.backend.config.WeaveSecurityProperties;
+import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
+import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -19,9 +24,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(
         controllers = WorkspaceController.class,
         excludeAutoConfiguration = OAuth2ResourceServerAutoConfiguration.class)
-@Import(SecurityConfig.class)
+@Import({SecurityConfig.class, WorkspaceCapabilityService.class})
+@EnableConfigurationProperties({
+        WeaveSecurityProperties.class,
+        WorkspaceCapabilityProperties.class,
+        OAuth2ResourceServerProperties.class
+})
 @org.springframework.test.context.TestPropertySource(properties = {
-        "spring.security.oauth2.resourceserver.jwt.issuer-uri=https://auth.example.invalid/realms/weave"
+        "spring.security.oauth2.resourceserver.jwt.issuer-uri=https://auth.example.invalid/realms/weave",
+        "weave.workspace.chat.dependency-url=https://matrix.weave.local",
+        "weave.workspace.files.dependency-url=https://nextcloud.weave.local"
 })
 class WorkspaceControllerTest {
 
@@ -32,7 +44,7 @@ class WorkspaceControllerTest {
     private JwtDecoder jwtDecoder;
 
     @Test
-    void returnsStaticWorkspaceCapabilities() throws Exception {
+    void returnsConfiguredWorkspaceCapabilities() throws Exception {
         mockMvc.perform(get("/api/v1/workspace/capabilities").with(jwt()
                         .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
                 .andExpect(status().isOk())

--- a/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
@@ -33,7 +33,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @org.springframework.test.context.TestPropertySource(properties = {
         "spring.security.oauth2.resourceserver.jwt.issuer-uri=https://auth.example.invalid/realms/weave",
         "weave.workspace.chat.dependency-url=https://matrix.weave.local",
-        "weave.workspace.files.dependency-url=https://nextcloud.weave.local"
+        "weave.workspace.files.dependency-url=https://nextcloud.weave.local",
+        "weave.workspace.calendar.enabled=true",
+        "weave.workspace.calendar.readiness=degraded"
 })
 class WorkspaceControllerTest {
 
@@ -52,8 +54,8 @@ class WorkspaceControllerTest {
                 .andExpect(jsonPath("$.shellAccess.readiness").value("ready"))
                 .andExpect(jsonPath("$.chat.readiness").value("ready"))
                 .andExpect(jsonPath("$.files.readiness").value("ready"))
-                .andExpect(jsonPath("$.calendar.enabled").value(false))
-                .andExpect(jsonPath("$.calendar.readiness").value("unavailable"))
+                .andExpect(jsonPath("$.calendar.enabled").value(true))
+                .andExpect(jsonPath("$.calendar.readiness").value("degraded"))
                 .andExpect(jsonPath("$.boards.readiness").value("unavailable"));
     }
 

--- a/src/test/java/com/massimotter/weave/backend/service/WorkspaceCapabilityServiceTest.java
+++ b/src/test/java/com/massimotter/weave/backend/service/WorkspaceCapabilityServiceTest.java
@@ -1,0 +1,52 @@
+package com.massimotter.weave.backend.service;
+
+import com.massimotter.weave.backend.config.WeaveSecurityProperties;
+import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WorkspaceCapabilityServiceTest {
+
+    @Test
+    void marksChatAndFilesDegradedUntilTheirRoutesAreConfigured() {
+        WorkspaceCapabilityService service = new WorkspaceCapabilityService(
+                resourceServerProperties("https://auth.example.invalid/realms/weave"),
+                new WeaveSecurityProperties("weave-app", "weave-app"),
+                new WorkspaceCapabilityProperties(null, null, null, null, null));
+
+        var snapshot = service.snapshot();
+
+        assertThat(snapshot.shellAccess().readiness()).isEqualTo(com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness.READY);
+        assertThat(snapshot.chat().enabled()).isTrue();
+        assertThat(snapshot.chat().readiness()).isEqualTo(com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness.DEGRADED);
+        assertThat(snapshot.files().readiness()).isEqualTo(com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness.DEGRADED);
+        assertThat(snapshot.calendar().readiness()).isEqualTo(com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness.UNAVAILABLE);
+    }
+
+    @Test
+    void blocksDependentCapabilitiesWhenShellAccessCannotValidateTokens() {
+        WorkspaceCapabilityService service = new WorkspaceCapabilityService(
+                resourceServerProperties(null),
+                new WeaveSecurityProperties("weave-app", "weave-app"),
+                new WorkspaceCapabilityProperties(
+                        new WorkspaceCapabilityProperties.Capability(true, null),
+                        new WorkspaceCapabilityProperties.Capability(true, "https://matrix.weave.local"),
+                        new WorkspaceCapabilityProperties.Capability(true, "https://nextcloud.weave.local"),
+                        null,
+                        null));
+
+        var snapshot = service.snapshot();
+
+        assertThat(snapshot.shellAccess().readiness()).isEqualTo(com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness.BLOCKED);
+        assertThat(snapshot.chat().readiness()).isEqualTo(com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness.BLOCKED);
+        assertThat(snapshot.files().readiness()).isEqualTo(com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness.BLOCKED);
+    }
+
+    private OAuth2ResourceServerProperties resourceServerProperties(String issuerUri) {
+        OAuth2ResourceServerProperties properties = new OAuth2ResourceServerProperties();
+        properties.getJwt().setIssuerUri(issuerUri);
+        return properties;
+    }
+}

--- a/src/test/java/com/massimotter/weave/backend/service/WorkspaceCapabilityServiceTest.java
+++ b/src/test/java/com/massimotter/weave/backend/service/WorkspaceCapabilityServiceTest.java
@@ -2,6 +2,7 @@ package com.massimotter.weave.backend.service;
 
 import com.massimotter.weave.backend.config.WeaveSecurityProperties;
 import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
 
@@ -18,11 +19,11 @@ class WorkspaceCapabilityServiceTest {
 
         var snapshot = service.snapshot();
 
-        assertThat(snapshot.shellAccess().readiness()).isEqualTo(com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness.READY);
+        assertThat(snapshot.shellAccess().readiness()).isEqualTo(WorkspaceCapabilityReadiness.READY);
         assertThat(snapshot.chat().enabled()).isTrue();
-        assertThat(snapshot.chat().readiness()).isEqualTo(com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness.DEGRADED);
-        assertThat(snapshot.files().readiness()).isEqualTo(com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness.DEGRADED);
-        assertThat(snapshot.calendar().readiness()).isEqualTo(com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness.UNAVAILABLE);
+        assertThat(snapshot.chat().readiness()).isEqualTo(WorkspaceCapabilityReadiness.DEGRADED);
+        assertThat(snapshot.files().readiness()).isEqualTo(WorkspaceCapabilityReadiness.DEGRADED);
+        assertThat(snapshot.calendar().readiness()).isEqualTo(WorkspaceCapabilityReadiness.UNAVAILABLE);
     }
 
     @Test
@@ -31,17 +32,57 @@ class WorkspaceCapabilityServiceTest {
                 resourceServerProperties(null),
                 new WeaveSecurityProperties("weave-app", "weave-app"),
                 new WorkspaceCapabilityProperties(
-                        new WorkspaceCapabilityProperties.Capability(true, null),
-                        new WorkspaceCapabilityProperties.Capability(true, "https://matrix.weave.local"),
-                        new WorkspaceCapabilityProperties.Capability(true, "https://nextcloud.weave.local"),
+                        new WorkspaceCapabilityProperties.Capability(true, null, null),
+                        new WorkspaceCapabilityProperties.Capability(true, "https://matrix.weave.local", null),
+                        new WorkspaceCapabilityProperties.Capability(true, "https://nextcloud.weave.local", null),
                         null,
                         null));
 
         var snapshot = service.snapshot();
 
-        assertThat(snapshot.shellAccess().readiness()).isEqualTo(com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness.BLOCKED);
-        assertThat(snapshot.chat().readiness()).isEqualTo(com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness.BLOCKED);
-        assertThat(snapshot.files().readiness()).isEqualTo(com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness.BLOCKED);
+        assertThat(snapshot.shellAccess().readiness()).isEqualTo(WorkspaceCapabilityReadiness.BLOCKED);
+        assertThat(snapshot.chat().readiness()).isEqualTo(WorkspaceCapabilityReadiness.BLOCKED);
+        assertThat(snapshot.files().readiness()).isEqualTo(WorkspaceCapabilityReadiness.BLOCKED);
+    }
+
+    @Test
+    void usesConfiguredReadinessOverridesForEnabledCapabilities() {
+        WorkspaceCapabilityService service = new WorkspaceCapabilityService(
+                resourceServerProperties("https://auth.example.invalid/realms/weave"),
+                new WeaveSecurityProperties("weave-app", "weave-app"),
+                new WorkspaceCapabilityProperties(
+                        new WorkspaceCapabilityProperties.Capability(true, null, null),
+                        new WorkspaceCapabilityProperties.Capability(true, "https://matrix.weave.local", WorkspaceCapabilityReadiness.DEGRADED),
+                        new WorkspaceCapabilityProperties.Capability(true, "https://nextcloud.weave.local", WorkspaceCapabilityReadiness.BLOCKED),
+                        new WorkspaceCapabilityProperties.Capability(true, null, WorkspaceCapabilityReadiness.READY),
+                        new WorkspaceCapabilityProperties.Capability(false, null, WorkspaceCapabilityReadiness.READY)));
+
+        var snapshot = service.snapshot();
+
+        assertThat(snapshot.chat().readiness()).isEqualTo(WorkspaceCapabilityReadiness.DEGRADED);
+        assertThat(snapshot.files().readiness()).isEqualTo(WorkspaceCapabilityReadiness.BLOCKED);
+        assertThat(snapshot.calendar().readiness()).isEqualTo(WorkspaceCapabilityReadiness.READY);
+        assertThat(snapshot.boards().readiness()).isEqualTo(WorkspaceCapabilityReadiness.UNAVAILABLE);
+    }
+
+    @Test
+    void marksShellAccessUnavailableWhenTheCapabilityIsDisabled() {
+        WorkspaceCapabilityService service = new WorkspaceCapabilityService(
+                resourceServerProperties("https://auth.example.invalid/realms/weave"),
+                new WeaveSecurityProperties("weave-app", "weave-app"),
+                new WorkspaceCapabilityProperties(
+                        new WorkspaceCapabilityProperties.Capability(false, null, null),
+                        new WorkspaceCapabilityProperties.Capability(true, "https://matrix.weave.local", null),
+                        new WorkspaceCapabilityProperties.Capability(true, "https://nextcloud.weave.local", null),
+                        null,
+                        null));
+
+        var snapshot = service.snapshot();
+
+        assertThat(snapshot.shellAccess().enabled()).isFalse();
+        assertThat(snapshot.shellAccess().readiness()).isEqualTo(WorkspaceCapabilityReadiness.UNAVAILABLE);
+        assertThat(snapshot.chat().readiness()).isEqualTo(WorkspaceCapabilityReadiness.READY);
+        assertThat(snapshot.files().readiness()).isEqualTo(WorkspaceCapabilityReadiness.READY);
     }
 
     private OAuth2ResourceServerProperties resourceServerProperties(String issuerUri) {


### PR DESCRIPTION
## Summary
- let workspace capabilities expose explicit readiness overrides for release truth instead of only URL-derived state
- mark shell access unavailable when the shell contract is intentionally disabled
- document and test the override behavior so the app can rely on capability state during Release 1

## Testing
- docker run --rm -u "501:20" -e HOME=/tmp -e GRADLE_USER_HOME=/tmp/.gradle -v "/Users/flotterotter/code:/workspace" -w /workspace eclipse-temurin:17-jdk ./gradlew test

Closes #11