### PR TITLE
fix(auth): fail closed when backend issuer is missing

### DIFF
--- a/src/main/java/com/massimotter/weave/backend/config/JwtDecoderConfig.java
+++ b/src/main/java/com/massimotter/weave/backend/config/JwtDecoderConfig.java
@@ -11,6 +11,7 @@ import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.util.StringUtils;
@@ -23,6 +24,12 @@ public class JwtDecoderConfig {
             OAuth2ResourceServerProperties resourceServerProperties,
             WeaveSecurityProperties weaveSecurityProperties) {
         String issuerUri = resourceServerProperties.getJwt().getIssuerUri();
+        if (!StringUtils.hasText(issuerUri)) {
+            return token -> {
+                throw new JwtException("The backend JWT issuer is not configured.");
+            };
+        }
+
         String jwkSetUri = resourceServerProperties.getJwt().getJwkSetUri();
         NimbusJwtDecoder jwtDecoder = StringUtils.hasText(jwkSetUri)
                 ? NimbusJwtDecoder.withJwkSetUri(jwkSetUri).build()

--- a/src/main/java/com/massimotter/weave/backend/config/JwtDecoderConfig.java
+++ b/src/main/java/com/massimotter/weave/backend/config/JwtDecoderConfig.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.BadJwtException;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtException;
@@ -26,7 +27,7 @@ public class JwtDecoderConfig {
         String issuerUri = resourceServerProperties.getJwt().getIssuerUri();
         if (!StringUtils.hasText(issuerUri)) {
             return token -> {
-                throw new JwtException("The backend JWT issuer is not configured.");
+                throw new BadJwtException("The backend JWT issuer is not configured.");
             };
         }
 

--- a/src/main/java/com/massimotter/weave/backend/controller/IdentityController.java
+++ b/src/main/java/com/massimotter/weave/backend/controller/IdentityController.java
@@ -12,6 +12,7 @@ import com.massimotter.weave.backend.model.ApiErrorResponse;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -44,10 +45,18 @@ public class IdentityController {
                 jwt.getClaimAsString("preferred_username"),
                 jwt.getClaimAsString("name"),
                 jwt.getClaimAsString("email"),
-                jwt.getClaimAsString("azp"),
+                issuedFor(jwt),
                 jwt.getAudience(),
                 extractRealmRoles(jwt),
                 extractStringList(jwt, "groups"));
+    }
+
+    private String issuedFor(Jwt jwt) {
+        return Stream.of(jwt.getClaimAsString("azp"), jwt.getClaimAsString("client_id"))
+                .filter(value -> value != null && !value.isBlank())
+                .map(String::trim)
+                .findFirst()
+                .orElse(null);
     }
 
     private List<String> extractRealmRoles(Jwt jwt) {

--- a/src/main/java/com/massimotter/weave/backend/service/WorkspaceReleaseReadinessService.java
+++ b/src/main/java/com/massimotter/weave/backend/service/WorkspaceReleaseReadinessService.java
@@ -130,7 +130,7 @@ public class WorkspaceReleaseReadinessService {
                     "Nextcloud files route",
                     readiness,
                     "Files are enabled but no Nextcloud route is configured yet.",
-                    "Set WEAVE_NEXTCLOUD_BASE_URL to the public Nextcloud base URL, for example https://weave.local/files.");
+                    "Set WEAVE_NEXTCLOUD_BASE_URL to the public Nextcloud base URL, for example https://nextcloud.weave.local.");
             case BLOCKED -> new WorkspaceReleaseReadinessCheckResponse(
                     "files",
                     "Nextcloud files route",

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,9 +8,10 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          # Required. Keycloak realm issuer used to validate JWT iss, exp, nbf, and signature.
+          # Required for a ready auth contract. Leave blank to start in blocked mode until
+          # the backend can validate JWT iss, exp, nbf, and signature against the public issuer.
           # Example: https://auth.example.com/realms/weave
-          issuer-uri: ${WEAVE_OIDC_ISSUER_URI}
+          issuer-uri: ${WEAVE_OIDC_ISSUER_URI:}
           # Optional. Use when the backend must fetch signing keys through an internal/private route
           # while preserving the public issuer URI in token validation.
           jwk-set-uri: ${WEAVE_OIDC_JWK_SET_URI:}

--- a/src/test/java/com/massimotter/weave/backend/config/FirstPartyIdentityContractTest.java
+++ b/src/test/java/com/massimotter/weave/backend/config/FirstPartyIdentityContractTest.java
@@ -106,6 +106,14 @@ class FirstPartyIdentityContractTest {
     }
 
     @Test
+    void normalizesIssuedForFromClientIdWhenAzpIsAbsent() throws Exception {
+        mockMvc.perform(get("/api/v1/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer client-id-only"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.issuedFor").value(FIRST_PARTY_CLIENT_ID));
+    }
+
+    @Test
     void acceptsValidFullFirstPartyToken() throws Exception {
         mockMvc.perform(get("/api/v1/me")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer valid-full-token"))

--- a/src/test/java/com/massimotter/weave/backend/config/JwtDecoderConfigTest.java
+++ b/src/test/java/com/massimotter/weave/backend/config/JwtDecoderConfigTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.security.oauth2.jwt.JwtValidationException;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -54,6 +55,15 @@ class JwtDecoderConfigTest {
             assertThrows(JwtValidationException.class,
                     () -> jwtDecoder.decode(signedToken(signingKey, "https://wrong.example.invalid/realms/weave")));
         }
+    }
+
+    @Test
+    void failsClosedWhenIssuerIsMissing() {
+        OAuth2ResourceServerProperties properties = new OAuth2ResourceServerProperties();
+
+        JwtDecoder jwtDecoder = new JwtDecoderConfig().jwtDecoder(properties, new WeaveSecurityProperties(null, null));
+
+        assertThrows(JwtException.class, () -> jwtDecoder.decode("token-value"));
     }
 
     private JwtDecoder jwtDecoder(String jwkSetUri) {

--- a/src/test/java/com/massimotter/weave/backend/config/MissingIssuerRuntimeContractTest.java
+++ b/src/test/java/com/massimotter/weave/backend/config/MissingIssuerRuntimeContractTest.java
@@ -1,0 +1,33 @@
+package com.massimotter.weave.backend.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class MissingIssuerRuntimeContractTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void startsWithoutIssuerAndFailsProtectedRoutesClosed() throws Exception {
+        mockMvc.perform(get("/actuator/health"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/v1/me")
+                        .header(AUTHORIZATION, "Bearer invalid-without-issuer"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error").value("Unauthorized"))
+                .andExpect(jsonPath("$.message").value(
+                        "Bearer authentication is required and must satisfy the first-party Weave token contract."));
+    }
+}

--- a/src/test/java/com/massimotter/weave/backend/controller/IdentityControllerTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/IdentityControllerTest.java
@@ -62,4 +62,15 @@ class IdentityControllerTest {
         mockMvc.perform(get("/api/v1/me"))
                 .andExpect(status().isUnauthorized());
     }
+
+    @Test
+    void fallsBackToClientIdWhenAzpIsAbsent() throws Exception {
+        mockMvc.perform(get("/api/v1/me").with(jwt().jwt(jwt -> jwt
+                        .subject("user-123")
+                        .claim("client_id", "weave-app")
+                        .claim("aud", List.of("weave-app")))
+                        .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.issuedFor").value("weave-app"));
+    }
 }

--- a/src/test/java/com/massimotter/weave/backend/service/WorkspaceReleaseReadinessServiceTest.java
+++ b/src/test/java/com/massimotter/weave/backend/service/WorkspaceReleaseReadinessServiceTest.java
@@ -18,7 +18,7 @@ class WorkspaceReleaseReadinessServiceTest {
                 new WorkspaceCapabilityProperties(
                         new WorkspaceCapabilityProperties.Capability(true, null, null),
                         new WorkspaceCapabilityProperties.Capability(true, "https://matrix.weave.local", null),
-                        new WorkspaceCapabilityProperties.Capability(true, "https://weave.local/files", null),
+                        new WorkspaceCapabilityProperties.Capability(true, "https://nextcloud.weave.local", null),
                         null,
                         null));
 
@@ -28,7 +28,7 @@ class WorkspaceReleaseReadinessServiceTest {
                 new WorkspaceCapabilityProperties(
                         new WorkspaceCapabilityProperties.Capability(true, null, null),
                         new WorkspaceCapabilityProperties.Capability(true, "https://matrix.weave.local", null),
-                        new WorkspaceCapabilityProperties.Capability(true, "https://weave.local/files", null),
+                        new WorkspaceCapabilityProperties.Capability(true, "https://nextcloud.weave.local", null),
                         null,
                         null),
                 capabilityService);
@@ -90,7 +90,7 @@ class WorkspaceReleaseReadinessServiceTest {
         assertThat(snapshot.readiness()).isEqualTo(WorkspaceCapabilityReadiness.DEGRADED);
         assertThat(snapshot.actions()).containsExactly(
                 "Set WEAVE_MATRIX_HOMESERVER_URL to the public Matrix base URL, for example https://matrix.weave.local.",
-                "Set WEAVE_NEXTCLOUD_BASE_URL to the public Nextcloud base URL, for example https://weave.local/files.");
+                "Set WEAVE_NEXTCLOUD_BASE_URL to the public Nextcloud base URL, for example https://nextcloud.weave.local.");
     }
 
     private OAuth2ResourceServerProperties resourceServerProperties(String issuerUri) {


### PR DESCRIPTION
## Summary
- fail closed at runtime when the backend JWT issuer is missing instead of booting into a misleading partial decoder state
- normalize issuedFor from client_id when azp is absent so first-party identity stays stable
- align release-readiness messaging with the current public Nextcloud hostname contract

## Validation
- local gradle test run is blocked in this shell because no Java runtime is installed
- contract coverage added in JwtDecoderConfigTest, MissingIssuerRuntimeContractTest, IdentityControllerTest, and FirstPartyIdentityContractTest
- downstream stack re-verified through weave-infra smoke test and weave live macOS integration test after the companion repo changes

## Cross-repo
- pairs with the weave PR for native Matrix sign-in and the weave-infra PR for MAS loopback support
