### PR TITLE
ci: use buildx for ghcr publish

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Summary
- configure the backend image publish workflow with docker/setup-buildx-action
- fix the live publish failure on main where GHA cache export was unsupported for the default docker driver
- keep the GHCR publish path runnable end-to-end

## Evidence
- main publish run 24741895987 failed with: 
