### PR TITLE
ci: pass published backend digest to live-stack

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -22,7 +22,8 @@ jobs:
     name: Build And Publish GHCR Image
     runs-on: ubuntu-latest
     outputs:
-      image_ref: ghcr.io/${{ github.repository_owner }}/weave-backend:sha-${{ github.sha }}
+      image_ref: ghcr.io/${{ github.repository_owner }}/weave-backend@${{ steps.build.outputs.digest }}
+      image_digest: ${{ steps.build.outputs.digest }}
 
     steps:
       - name: Check out repository
@@ -55,6 +56,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push image
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION
## Summary
- output the actual published GHCR digest from build-push-action
- pass a digest-pinned image reference into the live-stack verification workflow
- avoid assuming that :sha-<commit> always resolves to the pushed manifest

## Why
The publish workflow was forwarding `ghcr.io/...:sha-<commit>` as if it were the canonical artifact contract. The safer contract is the actual pushed manifest digest from `docker/build-push-action`.

## Effect
Live-stack verification now consumes a digest-pinned image reference directly.
