### PR TITLE
[codex] Add platform contract baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ The backend should act as a product API and orchestration layer, not as a blind 
 
 This repository now starts as a JWT-protected Spring Boot API with:
 
-- a `/api/v1/me` endpoint for claim inspection and client/backend contract testing
+- `/api/health/live` and `/api/health/ready` endpoints for gateway and smoke checks
+- `/api/platform/config` and `/api/platform/status` endpoints for client bootstrap and diagnostics
+- a canonical `/api/me` endpoint for profile claim inspection and client/backend contract testing
+- a compatibility `/api/v1/me` endpoint retained during the transition
 - a `/api/v1/workspace/capabilities` endpoint for the first backend-owned client contract
 - a `/api/v1/workspace/release-readiness` endpoint for operator-facing Release 1 setup status and remaining actions
 - OpenAPI JSON published at `/v3/api-docs`
@@ -52,6 +55,13 @@ Optional runtime variables:
 - `WEAVE_WORKSPACE_CALENDAR_READINESS`: optional explicit calendar readiness override (`ready`, `degraded`, `blocked`, `unavailable`)
 - `WEAVE_WORKSPACE_BOARDS_ENABLED`: enable the boards capability, defaults to `false`
 - `WEAVE_WORKSPACE_BOARDS_READINESS`: optional explicit boards readiness override (`ready`, `degraded`, `blocked`, `unavailable`)
+- `WEAVE_PUBLIC_BASE_URL`: public product entrypoint, defaults to `https://weave.local`
+- `WEAVE_API_BASE_URL`: public backend API base URL, defaults to `https://weave.local/api`
+- `WEAVE_AUTH_BASE_URL`: public Keycloak base URL, defaults to `https://auth.weave.local`
+- `WEAVE_MATRIX_BASE_URL`: public Matrix base URL, defaults to `https://matrix.weave.local`
+- `WEAVE_FILES_PRODUCT_URL`: public files product surface, defaults to `https://weave.local/files`
+- `WEAVE_CALENDAR_PRODUCT_URL`: public calendar product surface, defaults to `https://weave.local/calendar`
+- `WEAVE_NEXTCLOUD_RAW_BASE_URL`: raw Nextcloud fallback URL, defaults to `https://files.weave.local`
 - `PORT`: HTTP port, defaults to `8080`
 
 Workspace capability source of truth:
@@ -68,7 +78,7 @@ Local first-party token contract:
 - `iss` must match `WEAVE_OIDC_ISSUER_URI`.
 - `aud` must include `weave-app` unless `WEAVE_OIDC_REQUIRED_AUDIENCE` overrides it.
 - `azp` and/or `client_id` must be present and must match `weave-app` unless `WEAVE_CLIENT_ID` overrides it.
-- `scope` must include `weave:workspace` for `/api/v1/**`.
+- `scope` must include `weave:workspace` for protected `/api/**` routes. Public platform, liveness, and readiness endpoints are unauthenticated.
 
 ## Local validation
 
@@ -101,9 +111,10 @@ This Dockerfile-based path is the reproducible local image build for Apple Silic
 
 ## Release-grade API behavior
 
-- `/api/v1/**` returns structured JSON for `401` and `403` responses.
+- Protected `/api/**` routes return structured JSON for `401` and `403` responses.
 - `401` means the bearer token is missing or fails the first-party Weave token contract.
 - `403` means the caller is authenticated but lacks the `weave:workspace` scope.
+- The stable error envelope is `code`, `message`, `details`, and `requestId`; the response also includes `X-Request-Id`.
 - `/v3/api-docs` publishes the same error schema so app and operator tooling can rely on it.
 
 ## Architecture alignment

--- a/docs/architecture-alignment.md
+++ b/docs/architecture-alignment.md
@@ -32,8 +32,8 @@ Own the runnable environment and integration contract:
 ## Gaps found in the current state
 
 1. `weave` uses `com.massimotter.weave:/oauthredirect` and `com.massimotter.weave:/logout`, while `weave-inf` currently registers `weaveapp://login/callback` for the `weave-app` Keycloak client.
-2. `weave` derives `https://nextcloud.<base-domain>`, while `weave-inf` currently exposes Nextcloud on `files.<tenant_domain>`.
-3. `weave` requires an HTTPS issuer and enforces HTTPS for live Nextcloud use, while `weave-inf` still defaults to `http://...:8090` local ingress.
+2. Older client defaults derived `nextcloud.<base-domain>` and `api.<base-domain>` instead of the final `files.<base-domain>` raw fallback and `<base-domain>/api` product API route.
+3. Older local infrastructure exposed service-specific localhost routes instead of the final `https://weave.local` gateway plus `https://auth.weave.local`, `https://matrix.weave.local`, and `https://files.weave.local`.
 4. The original `weave-backend` spike assumed that user bearer tokens could be forwarded directly into Nextcloud and Matrix calls. That is the wrong default boundary for this stack.
 5. The original backend spike did not compile in a clean Gradle/JDK environment because it used `WebClient` types without the needed reactive dependency and mixed incompatible OAuth client wiring.
 

--- a/docs/issues/weave-inf/deploy-weave-backend-and-finalize-keycloak-contract.md
+++ b/docs/issues/weave-inf/deploy-weave-backend-and-finalize-keycloak-contract.md
@@ -10,7 +10,7 @@
 
 ## Proposal
 
-- Add a backend runtime to the infrastructure stack, exposed on a dedicated host such as `api.<tenant_domain>`
+- Add a backend runtime to the infrastructure stack, exposed through the product gateway at `https://<tenant_domain>/api`
 - Promote the backend client model from placeholder to a documented contract:
   - issuer URI
   - backend base URL

--- a/docs/issues/weave-inf/enable-local-tls-and-align-public-hostnames.md
+++ b/docs/issues/weave-inf/enable-local-tls-and-align-public-hostnames.md
@@ -7,21 +7,21 @@ The Flutter app requires:
 - an HTTPS OIDC issuer
 - HTTPS Nextcloud access for the live integration flow
 
-`weave-inf` still defaults to an HTTP ingress on `:8090`, and it exposes Nextcloud on `files.<tenant_domain>` while the app derives `nextcloud.<base-domain>`.
+Older `weave-inf` revisions defaulted to an HTTP ingress on `:8090` and service-specific hosts that did not match the final product gateway topology.
 
 ## Proposal
 
-- Add local TLS termination for the browser-facing stack, ideally through Traefik with a dev CA or mkcert-style certificates
+- Add local TLS termination for the browser-facing stack through Caddy with generated local certificates
 - Align public hostnames with the app contract:
+  - `<tenant_domain>` for the product gateway and `/api`
   - `auth.<tenant_domain>`
-  - `mas.<tenant_domain>`
   - `matrix.<tenant_domain>`
-  - `nextcloud.<tenant_domain>`
+  - `files.<tenant_domain>` for raw Nextcloud fallback
 - Export the final browser-facing URLs as Terraform outputs or generated install metadata for client/backend consumers
 
 ## Acceptance criteria
 
 - the stack can be reached over HTTPS with the configured hostnames
-- Nextcloud uses the final agreed hostname instead of `files.<tenant_domain>`
+- Nextcloud uses `files.<tenant_domain>` as the raw fallback while the product gateway owns `/files`
 - installer output shows the HTTPS URLs that the client and backend should consume
 - local bootstrap docs include the trusted certificate/dev CA step needed for mobile or desktop testing

--- a/docs/issues/weave/align-native-oidc-and-derived-endpoints.md
+++ b/docs/issues/weave/align-native-oidc-and-derived-endpoints.md
@@ -6,14 +6,15 @@
 
 - OIDC redirect: `com.massimotter.weave:/oauthredirect`
 - OIDC post-logout redirect: `com.massimotter.weave:/logout`
-- derived Nextcloud URL: `https://nextcloud.<base-domain>`
+- derived raw Nextcloud fallback URL: `https://files.<base-domain>`
+- derived backend API URL: `https://<base-domain>/api`
 
-The current `weave-inf` setup still registers `weaveapp://login/callback` for the Keycloak client and exposes Nextcloud on `files.<tenant_domain>`, so the default infrastructure contract does not match the client code.
+Older `weave-inf` setup registered `weaveapp://login/callback` for the Keycloak client and older app defaults derived service-specific hosts that no longer match the final product topology.
 
 ## Proposal
 
 - Align the client-side constants and onboarding/help copy with the final infrastructure contract
-- Prefer `nextcloud.<base-domain>` as the default host to match the current app architecture and naming
+- Prefer `files.<base-domain>` for the raw Nextcloud fallback and `<base-domain>/api` for the product API route
 - Make the redirect URI contract explicit in app docs so infra changes do not silently break native sign-in
 
 ## Acceptance criteria

--- a/docs/release-operations.md
+++ b/docs/release-operations.md
@@ -13,26 +13,38 @@ Optional:
 - `WEAVE_OIDC_JWK_SET_URI`: internal JWKS URL when the backend cannot use the issuer metadata endpoint directly
 - `WEAVE_OIDC_REQUIRED_AUDIENCE`: required audience in Weave access tokens, defaults to `weave-app`
 - `WEAVE_CLIENT_ID`: required first-party client identifier in `azp` and/or `client_id`, defaults to `weave-app`
+- `WEAVE_PUBLIC_BASE_URL`: public product entrypoint, defaults to `https://weave.local`
+- `WEAVE_API_BASE_URL`: public backend API base URL, defaults to `https://weave.local/api`
+- `WEAVE_AUTH_BASE_URL`: public Keycloak base URL, defaults to `https://auth.weave.local`
+- `WEAVE_MATRIX_BASE_URL`: public Matrix base URL, defaults to `https://matrix.weave.local`
+- `WEAVE_FILES_PRODUCT_URL`: public files product surface, defaults to `https://weave.local/files`
+- `WEAVE_CALENDAR_PRODUCT_URL`: public calendar product surface, defaults to `https://weave.local/calendar`
+- `WEAVE_NEXTCLOUD_RAW_BASE_URL`: raw Nextcloud fallback URL, defaults to `https://files.weave.local`
 - `PORT`: HTTP listen port, defaults to `8080`
 
 ## Protected API behavior
 
-All `/api/v1/**` routes require a bearer token that satisfies the first-party Weave contract:
+Protected `/api/**` routes require a bearer token that satisfies the first-party Weave contract:
 
 - `iss` matches `WEAVE_OIDC_ISSUER_URI`
 - `aud` includes `WEAVE_OIDC_REQUIRED_AUDIENCE`
 - `azp` and/or `client_id` matches `WEAVE_CLIENT_ID`
 - `scope` includes `weave:workspace`
 
-Protected endpoints return a stable JSON error envelope on auth failures:
+`/api/health/live`, `/api/health/ready`, `/api/platform/config`, and `/api/platform/status` are public diagnostics/bootstrap endpoints.
+
+Protected endpoints return a stable JSON error envelope on auth failures and include the same request id in `X-Request-Id`:
 
 ```json
 {
-  "timestamp": "2026-04-20T11:32:15.123Z",
-  "status": 401,
-  "error": "Unauthorized",
+  "code": "unauthorized",
   "message": "Bearer authentication is required and must satisfy the first-party Weave token contract.",
-  "path": "/api/v1/workspace/capabilities"
+  "details": {
+    "status": 401,
+    "path": "/api/v1/workspace/capabilities",
+    "error": "Unauthorized"
+  },
+  "requestId": "01HV..."
 }
 ```
 
@@ -42,9 +54,11 @@ Use `401` for missing or invalid tokens. Use `403` when the token is authenticat
 
 ## Minimum operator checks
 
-- `GET /actuator/health` should return `200 OK`
+- `GET /api/health/ready` should return `200 OK`
 - `GET /v3/api-docs` should return the published OpenAPI document
-- `GET /api/v1/me` with a valid first-party token should return caller claims
+- `GET /api/platform/config` should return public product URLs and module flags
+- `GET /api/platform/status` should return module status for smoke and diagnostics
+- `GET /api/me` with a valid first-party token should return caller claims
 - `GET /api/v1/workspace/capabilities` with a valid first-party token should return the client-facing capability snapshot
 - `GET /api/v1/workspace/release-readiness` with a valid first-party token should return operator-facing Release 1 setup status and remaining actions
 

--- a/src/main/java/com/massimotter/weave/backend/WeaveBackendApplication.java
+++ b/src/main/java/com/massimotter/weave/backend/WeaveBackendApplication.java
@@ -1,5 +1,6 @@
 package com.massimotter.weave.backend;
 
+import com.massimotter.weave.backend.config.PlatformContractProperties;
 import com.massimotter.weave.backend.config.WeaveSecurityProperties;
 import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
 import org.springframework.boot.SpringApplication;
@@ -7,7 +8,11 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
-@EnableConfigurationProperties({WeaveSecurityProperties.class, WorkspaceCapabilityProperties.class})
+@EnableConfigurationProperties({
+        PlatformContractProperties.class,
+        WeaveSecurityProperties.class,
+        WorkspaceCapabilityProperties.class
+})
 public class WeaveBackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/massimotter/weave/backend/config/ApiAccessDeniedHandler.java
+++ b/src/main/java/com/massimotter/weave/backend/config/ApiAccessDeniedHandler.java
@@ -25,6 +25,7 @@ public class ApiAccessDeniedHandler implements AccessDeniedHandler {
                 request,
                 response,
                 HttpStatus.FORBIDDEN,
+                "forbidden",
                 "The bearer token is authenticated but missing the required weave:workspace scope.");
     }
 }

--- a/src/main/java/com/massimotter/weave/backend/config/ApiAuthenticationEntryPoint.java
+++ b/src/main/java/com/massimotter/weave/backend/config/ApiAuthenticationEntryPoint.java
@@ -25,6 +25,7 @@ public class ApiAuthenticationEntryPoint implements AuthenticationEntryPoint {
                 request,
                 response,
                 HttpStatus.UNAUTHORIZED,
+                "unauthorized",
                 "Bearer authentication is required and must satisfy the first-party Weave token contract.");
     }
 }

--- a/src/main/java/com/massimotter/weave/backend/config/ApiErrorResponseWriter.java
+++ b/src/main/java/com/massimotter/weave/backend/config/ApiErrorResponseWriter.java
@@ -5,7 +5,9 @@ import com.massimotter.weave.backend.model.ApiErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -21,14 +23,37 @@ public class ApiErrorResponseWriter {
 
     public void write(HttpServletRequest request, HttpServletResponse response, HttpStatus status, String message)
             throws IOException {
+        write(request, response, status, defaultCode(status), message);
+    }
+
+    public void write(HttpServletRequest request, HttpServletResponse response, HttpStatus status, String code,
+            String message)
+            throws IOException {
         response.setStatus(status.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
+        String requestId = requestId(request);
+        response.setHeader("X-Request-Id", requestId);
+        Map<String, Object> details = new LinkedHashMap<>();
+        details.put("status", status.value());
+        details.put("path", request.getRequestURI());
+        details.put("error", status.getReasonPhrase());
         objectMapper.writeValue(response.getWriter(), new ApiErrorResponse(
-                Instant.now().toString(),
-                status.value(),
-                status.getReasonPhrase(),
+                code,
                 message,
-                request.getRequestURI()));
+                details,
+                requestId));
+    }
+
+    private String defaultCode(HttpStatus status) {
+        return status.name().toLowerCase().replace('_', '-');
+    }
+
+    private String requestId(HttpServletRequest request) {
+        String incoming = request.getHeader("X-Request-Id");
+        if (incoming != null && !incoming.isBlank()) {
+            return incoming.trim();
+        }
+        return UUID.randomUUID().toString();
     }
 }

--- a/src/main/java/com/massimotter/weave/backend/config/PlatformContractProperties.java
+++ b/src/main/java/com/massimotter/weave/backend/config/PlatformContractProperties.java
@@ -1,0 +1,36 @@
+package com.massimotter.weave.backend.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "weave.platform")
+public record PlatformContractProperties(
+        String publicBaseUrl,
+        String apiBaseUrl,
+        String authBaseUrl,
+        String matrixBaseUrl,
+        String filesProductUrl,
+        String calendarProductUrl,
+        String nextcloudRawBaseUrl,
+        Targets targets) {
+
+    public PlatformContractProperties {
+        publicBaseUrl = defaultIfBlank(publicBaseUrl, "https://weave.local");
+        apiBaseUrl = defaultIfBlank(apiBaseUrl, "https://weave.local/api");
+        authBaseUrl = defaultIfBlank(authBaseUrl, "https://auth.weave.local");
+        matrixBaseUrl = defaultIfBlank(matrixBaseUrl, "https://matrix.weave.local");
+        filesProductUrl = defaultIfBlank(filesProductUrl, "https://weave.local/files");
+        calendarProductUrl = defaultIfBlank(calendarProductUrl, "https://weave.local/calendar");
+        nextcloudRawBaseUrl = defaultIfBlank(nextcloudRawBaseUrl, "https://files.weave.local");
+        targets = targets == null ? new Targets(true, true, false) : targets;
+    }
+
+    private static String defaultIfBlank(String value, String fallback) {
+        if (value == null || value.isBlank()) {
+            return fallback;
+        }
+        return value.trim();
+    }
+
+    public record Targets(boolean mobile, boolean desktop, boolean web) {
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/config/SecurityConfig.java
+++ b/src/main/java/com/massimotter/weave/backend/config/SecurityConfig.java
@@ -45,7 +45,9 @@ public class SecurityConfig {
                         .accessDeniedHandler(accessDeniedHandler))
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/actuator/health", "/actuator/info", "/error").permitAll()
+                        .requestMatchers("/api/health/**", "/api/platform/config", "/api/platform/status").permitAll()
                         .requestMatchers("/v3/api-docs", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/api/**").hasAuthority(WORKSPACE_SCOPE_AUTHORITY)
                         .requestMatchers("/api/v1/**").hasAuthority(WORKSPACE_SCOPE_AUTHORITY)
                         .anyRequest().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2

--- a/src/main/java/com/massimotter/weave/backend/controller/HealthController.java
+++ b/src/main/java/com/massimotter/weave/backend/controller/HealthController.java
@@ -1,0 +1,35 @@
+package com.massimotter.weave.backend.controller;
+
+import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
+import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthController {
+
+    private final WorkspaceCapabilityService workspaceCapabilityService;
+
+    public HealthController(WorkspaceCapabilityService workspaceCapabilityService) {
+        this.workspaceCapabilityService = workspaceCapabilityService;
+    }
+
+    @GetMapping("/api/health/live")
+    public Map<String, String> live() {
+        return Map.of("status", "up");
+    }
+
+    @GetMapping("/api/health/ready")
+    public ResponseEntity<Map<String, String>> ready() {
+        WorkspaceCapabilityReadiness readiness = workspaceCapabilityService.snapshot().shellAccess().readiness();
+        if (readiness == WorkspaceCapabilityReadiness.READY) {
+            return ResponseEntity.ok(Map.of("status", "up"));
+        }
+        return ResponseEntity
+                .status(HttpStatus.SERVICE_UNAVAILABLE)
+                .body(Map.of("status", "blocked", "reason", "auth_contract_incomplete"));
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/controller/IdentityController.java
+++ b/src/main/java/com/massimotter/weave/backend/controller/IdentityController.java
@@ -9,25 +9,27 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import com.massimotter.weave.backend.model.AuthenticatedUserResponse;
 import com.massimotter.weave.backend.model.ApiErrorResponse;
+import com.massimotter.weave.backend.model.ModuleSyncStatusResponse;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1")
 @Tag(name = "Identity", description = "Authenticated caller introspection endpoints.")
 public class IdentityController {
 
-    @GetMapping("/me")
+    private static final List<String> MVP_ROLES = List.of("owner", "admin", "member", "guest");
+
+    @GetMapping({"/api/me", "/api/v1/me"})
     @Operation(
             summary = "Get the authenticated caller profile",
-            description = "Returns the normalized identity claims available to the Weave backend.",
+            description = "Returns the canonical Weave identity and profile snapshot available to the backend.",
             security = @SecurityRequirement(name = "bearer-jwt"))
     @ApiResponses({
             @ApiResponse(
@@ -40,15 +42,29 @@ public class IdentityController {
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
     })
     public AuthenticatedUserResponse me(@AuthenticationPrincipal Jwt jwt) {
+        String subject = jwt.getSubject();
+        String username = firstText(jwt.getClaimAsString("preferred_username"), subject);
+        String displayName = firstText(jwt.getClaimAsString("name"), username);
+        String email = jwt.getClaimAsString("email");
+        List<String> realmRoles = extractRealmRoles(jwt);
+        List<String> groups = extractStringList(jwt, "groups");
         return new AuthenticatedUserResponse(
-                jwt.getSubject(),
-                jwt.getClaimAsString("preferred_username"),
-                jwt.getClaimAsString("name"),
-                jwt.getClaimAsString("email"),
+                subject,
+                username,
+                email,
+                emailVerified(jwt),
+                displayName,
+                firstText(jwt.getClaimAsString("locale"), "en"),
+                firstText(jwt.getClaimAsString("timezone"), "UTC"),
+                productRoles(realmRoles),
+                groups,
+                subject,
+                username,
+                displayName,
                 issuedFor(jwt),
                 jwt.getAudience(),
-                extractRealmRoles(jwt),
-                extractStringList(jwt, "groups"));
+                realmRoles,
+                new ModuleSyncStatusResponse("not_configured", "not_configured"));
     }
 
     private String issuedFor(Jwt jwt) {
@@ -92,5 +108,26 @@ public class IdentityController {
                 .filter(value -> !value.isEmpty())
                 .sorted()
                 .toList();
+    }
+
+    private boolean emailVerified(Jwt jwt) {
+        Object value = jwt.getClaims().get("email_verified");
+        return value instanceof Boolean verified && verified;
+    }
+
+    private List<String> productRoles(List<String> realmRoles) {
+        return realmRoles.stream()
+                .map(role -> role.toLowerCase(Locale.ROOT))
+                .filter(MVP_ROLES::contains)
+                .distinct()
+                .sorted()
+                .toList();
+    }
+
+    private String firstText(String primary, String fallback) {
+        if (primary != null && !primary.isBlank()) {
+            return primary.trim();
+        }
+        return fallback;
     }
 }

--- a/src/main/java/com/massimotter/weave/backend/controller/PlatformController.java
+++ b/src/main/java/com/massimotter/weave/backend/controller/PlatformController.java
@@ -1,0 +1,32 @@
+package com.massimotter.weave.backend.controller;
+
+import com.massimotter.weave.backend.model.PlatformConfigResponse;
+import com.massimotter.weave.backend.model.PlatformStatusResponse;
+import com.massimotter.weave.backend.service.PlatformContractService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Tag(name = "Platform", description = "Public platform configuration and module status endpoints.")
+public class PlatformController {
+
+    private final PlatformContractService platformContractService;
+
+    public PlatformController(PlatformContractService platformContractService) {
+        this.platformContractService = platformContractService;
+    }
+
+    @GetMapping("/api/platform/config")
+    @Operation(summary = "Get public platform configuration")
+    public PlatformConfigResponse config() {
+        return platformContractService.config();
+    }
+
+    @GetMapping("/api/platform/status")
+    @Operation(summary = "Get platform module status")
+    public PlatformStatusResponse status() {
+        return platformContractService.status();
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/model/ApiErrorResponse.java
+++ b/src/main/java/com/massimotter/weave/backend/model/ApiErrorResponse.java
@@ -1,17 +1,16 @@
 package com.massimotter.weave.backend.model;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Map;
 
 @Schema(description = "Stable JSON error envelope returned by protected API endpoints.")
 public record ApiErrorResponse(
-        @Schema(description = "UTC timestamp when the error response was generated.", example = "2026-04-20T11:32:15.123Z")
-        String timestamp,
-        @Schema(description = "HTTP status code.", example = "401")
-        int status,
-        @Schema(description = "Short error category.", example = "Unauthorized")
-        String error,
+        @Schema(description = "Stable machine-readable error code.", example = "unauthorized")
+        String code,
         @Schema(description = "Operator-facing explanation of what failed.", example = "Bearer authentication is required to access this endpoint.")
         String message,
-        @Schema(description = "Request path that produced the error.", example = "/api/v1/workspace/capabilities")
-        String path) {
+        @Schema(description = "Non-secret diagnostic details for this failure.")
+        Map<String, Object> details,
+        @Schema(description = "Correlation identifier for support and log lookup.", example = "8c2f4d7a-4d5f-4f88-92e8-4fcbb81dd527")
+        String requestId) {
 }

--- a/src/main/java/com/massimotter/weave/backend/model/AuthenticatedUserResponse.java
+++ b/src/main/java/com/massimotter/weave/backend/model/AuthenticatedUserResponse.java
@@ -1,14 +1,40 @@
 package com.massimotter.weave.backend.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
+@Schema(description = "Canonical Weave identity and product profile snapshot for the authenticated user.")
 public record AuthenticatedUserResponse(
-        String sub,
-        String preferredUsername,
-        String name,
+        @Schema(description = "Stable immutable Weave user identifier, backed by the Keycloak subject.")
+        String userId,
+        @Schema(description = "Stable login/workspace handle.")
+        String username,
+        @Schema(description = "Verified email address when available.")
         String email,
+        @Schema(description = "Whether Keycloak reports the email address as verified.")
+        boolean emailVerified,
+        @Schema(description = "User-visible product display name.")
+        String displayName,
+        @Schema(description = "Preferred locale.")
+        String locale,
+        @Schema(description = "Preferred timezone.")
+        String timezone,
+        @Schema(description = "MVP product roles.")
+        List<String> roles,
+        @Schema(description = "Workspace or module groups.")
+        List<String> groups,
+        @Schema(description = "Legacy Keycloak subject alias retained during /api/v1 transition.")
+        String sub,
+        @Schema(description = "Legacy preferred username alias retained during /api/v1 transition.")
+        String preferredUsername,
+        @Schema(description = "Legacy display name alias retained during /api/v1 transition.")
+        String name,
+        @Schema(description = "Authorized party/client that requested the token.")
         String issuedFor,
+        @Schema(description = "Token audience values.")
         List<String> audience,
+        @Schema(description = "Raw realm roles from Keycloak.")
         List<String> realmRoles,
-        List<String> groups) {
+        @Schema(description = "Product profile sync status by module.")
+        ModuleSyncStatusResponse moduleSyncStatus) {
 }

--- a/src/main/java/com/massimotter/weave/backend/model/ModuleSyncStatusResponse.java
+++ b/src/main/java/com/massimotter/weave/backend/model/ModuleSyncStatusResponse.java
@@ -1,0 +1,11 @@
+package com.massimotter.weave.backend.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Current profile synchronization status for backing modules.")
+public record ModuleSyncStatusResponse(
+        @Schema(description = "Matrix profile sync status.", example = "not_configured")
+        String matrix,
+        @Schema(description = "Nextcloud profile sync status.", example = "not_configured")
+        String nextcloud) {
+}

--- a/src/main/java/com/massimotter/weave/backend/model/PlatformConfigResponse.java
+++ b/src/main/java/com/massimotter/weave/backend/model/PlatformConfigResponse.java
@@ -1,0 +1,27 @@
+package com.massimotter.weave.backend.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Public platform configuration consumed by Weave clients.")
+public record PlatformConfigResponse(
+        String publicBaseUrl,
+        String apiBaseUrl,
+        String authBaseUrl,
+        String matrixBaseUrl,
+        String filesProductUrl,
+        String calendarProductUrl,
+        String nextcloudRawBaseUrl,
+        Targets targets,
+        Features features) {
+
+    public record Targets(boolean mobile, boolean desktop, boolean web) {
+    }
+
+    public record Features(
+            boolean chat,
+            boolean chatE2ee,
+            boolean matrixFederation,
+            boolean files,
+            boolean calendar) {
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/model/PlatformStatusResponse.java
+++ b/src/main/java/com/massimotter/weave/backend/model/PlatformStatusResponse.java
@@ -1,0 +1,17 @@
+package com.massimotter.weave.backend.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Backend-owned status snapshot for admin diagnostics and smoke tests.")
+public record PlatformStatusResponse(
+        SimpleStatus backend,
+        SimpleStatus auth,
+        MatrixStatus matrix,
+        SimpleStatus nextcloud) {
+
+    public record SimpleStatus(String status) {
+    }
+
+    public record MatrixStatus(String status, boolean federationEnabled, boolean e2eeEnabled) {
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/service/PlatformContractService.java
+++ b/src/main/java/com/massimotter/weave/backend/service/PlatformContractService.java
@@ -1,0 +1,70 @@
+package com.massimotter.weave.backend.service;
+
+import com.massimotter.weave.backend.config.PlatformContractProperties;
+import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
+import com.massimotter.weave.backend.model.PlatformConfigResponse;
+import com.massimotter.weave.backend.model.PlatformStatusResponse;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PlatformContractService {
+
+    private final OAuth2ResourceServerProperties resourceServerProperties;
+    private final PlatformContractProperties platformProperties;
+    private final WorkspaceCapabilityProperties workspaceProperties;
+
+    public PlatformContractService(
+            OAuth2ResourceServerProperties resourceServerProperties,
+            PlatformContractProperties platformProperties,
+            WorkspaceCapabilityProperties workspaceProperties) {
+        this.resourceServerProperties = resourceServerProperties;
+        this.platformProperties = platformProperties;
+        this.workspaceProperties = workspaceProperties;
+    }
+
+    public PlatformConfigResponse config() {
+        return new PlatformConfigResponse(
+                platformProperties.publicBaseUrl(),
+                platformProperties.apiBaseUrl(),
+                platformProperties.authBaseUrl(),
+                platformProperties.matrixBaseUrl(),
+                platformProperties.filesProductUrl(),
+                platformProperties.calendarProductUrl(),
+                platformProperties.nextcloudRawBaseUrl(),
+                new PlatformConfigResponse.Targets(
+                        platformProperties.targets().mobile(),
+                        platformProperties.targets().desktop(),
+                        platformProperties.targets().web()),
+                new PlatformConfigResponse.Features(
+                        workspaceProperties.chat().enabled(),
+                        false,
+                        false,
+                        workspaceProperties.files().enabled(),
+                        workspaceProperties.calendar().enabled()));
+    }
+
+    public PlatformStatusResponse status() {
+        return new PlatformStatusResponse(
+                new PlatformStatusResponse.SimpleStatus("up"),
+                new PlatformStatusResponse.SimpleStatus(hasText(resourceServerProperties.getJwt().getIssuerUri())
+                        ? "up"
+                        : "blocked"),
+                new PlatformStatusResponse.MatrixStatus(moduleStatus(workspaceProperties.chat()), false, false),
+                new PlatformStatusResponse.SimpleStatus(moduleStatus(workspaceProperties.files())));
+    }
+
+    private String moduleStatus(WorkspaceCapabilityProperties.Capability capability) {
+        if (!capability.enabled()) {
+            return "disabled";
+        }
+        if (capability.readiness() != null) {
+            return capability.readiness().name().toLowerCase();
+        }
+        return hasText(capability.dependencyUrl()) ? "up" : "degraded";
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/service/WorkspaceReleaseReadinessService.java
+++ b/src/main/java/com/massimotter/weave/backend/service/WorkspaceReleaseReadinessService.java
@@ -130,7 +130,7 @@ public class WorkspaceReleaseReadinessService {
                     "Nextcloud files route",
                     readiness,
                     "Files are enabled but no Nextcloud route is configured yet.",
-                    "Set WEAVE_NEXTCLOUD_BASE_URL to the public Nextcloud base URL, for example https://nextcloud.weave.local.");
+                    "Set WEAVE_NEXTCLOUD_BASE_URL to the raw Nextcloud fallback URL, for example https://files.weave.local.");
             case BLOCKED -> new WorkspaceReleaseReadinessCheckResponse(
                     "files",
                     "Nextcloud files route",

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,22 @@ management:
         enabled: true
 
 weave:
+  platform:
+    public-base-url: ${WEAVE_PUBLIC_BASE_URL:https://weave.local}
+    api-base-url: ${WEAVE_API_BASE_URL:https://weave.local/api}
+    auth-base-url: ${WEAVE_AUTH_BASE_URL:https://auth.weave.local}
+    matrix-base-url: ${WEAVE_MATRIX_BASE_URL:${WEAVE_MATRIX_HOMESERVER_URL:https://matrix.weave.local}}
+    files-product-url: ${WEAVE_FILES_PRODUCT_URL:https://weave.local/files}
+    calendar-product-url: ${WEAVE_CALENDAR_PRODUCT_URL:https://weave.local/calendar}
+    nextcloud-raw-base-url: ${WEAVE_NEXTCLOUD_RAW_BASE_URL:${WEAVE_NEXTCLOUD_BASE_URL:https://files.weave.local}}
+    targets:
+      mobile: ${WEAVE_TARGET_MOBILE:true}
+      desktop: ${WEAVE_TARGET_DESKTOP:true}
+      web: ${WEAVE_TARGET_WEB:false}
+    features:
+      chat: ${WEAVE_FEATURE_CHAT_ENABLED:true}
+      files: ${WEAVE_FEATURE_FILES_ENABLED:true}
+      calendar: ${WEAVE_FEATURE_CALENDAR_ENABLED:true}
   security:
     # JWT aud must include the first-party Weave app audience.
     required-audience: ${WEAVE_OIDC_REQUIRED_AUDIENCE:weave-app}
@@ -37,14 +53,14 @@ weave:
       enabled: ${WEAVE_WORKSPACE_SHELL_ACCESS_ENABLED:true}
     chat:
       enabled: ${WEAVE_WORKSPACE_CHAT_ENABLED:true}
-      dependency-url: ${WEAVE_MATRIX_HOMESERVER_URL:}
+      dependency-url: ${WEAVE_MATRIX_HOMESERVER_URL:${WEAVE_MATRIX_BASE_URL:https://matrix.weave.local}}
       readiness: ${WEAVE_WORKSPACE_CHAT_READINESS:}
     files:
       enabled: ${WEAVE_WORKSPACE_FILES_ENABLED:true}
-      dependency-url: ${WEAVE_NEXTCLOUD_BASE_URL:}
+      dependency-url: ${WEAVE_NEXTCLOUD_BASE_URL:${WEAVE_NEXTCLOUD_RAW_BASE_URL:https://files.weave.local}}
       readiness: ${WEAVE_WORKSPACE_FILES_READINESS:}
     calendar:
-      enabled: ${WEAVE_WORKSPACE_CALENDAR_ENABLED:false}
+      enabled: ${WEAVE_WORKSPACE_CALENDAR_ENABLED:true}
       readiness: ${WEAVE_WORKSPACE_CALENDAR_READINESS:}
     boards:
       enabled: ${WEAVE_WORKSPACE_BOARDS_ENABLED:false}

--- a/src/test/java/com/massimotter/weave/backend/config/FirstPartyIdentityContractTest.java
+++ b/src/test/java/com/massimotter/weave/backend/config/FirstPartyIdentityContractTest.java
@@ -21,9 +21,8 @@ import org.springframework.security.oauth2.jwt.JwtValidationException;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.endsWith;
-import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -64,12 +63,12 @@ class FirstPartyIdentityContractTest {
         mockMvc.perform(get("/api/v1/workspace/capabilities")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + tokenValue))
                 .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.status").value(401))
-                .andExpect(jsonPath("$.error").value("Unauthorized"))
+                .andExpect(jsonPath("$.code").value("unauthorized"))
                 .andExpect(jsonPath("$.message").value(
                         "Bearer authentication is required and must satisfy the first-party Weave token contract."))
-                .andExpect(jsonPath("$.path").value(endsWith("/api/v1/workspace/capabilities")))
-                .andExpect(jsonPath("$.timestamp").value(not(emptyOrNullString())));
+                .andExpect(jsonPath("$.details.status").value(401))
+                .andExpect(jsonPath("$.details.path").value(endsWith("/api/v1/workspace/capabilities")))
+                .andExpect(jsonPath("$.requestId").value(notNullValue()));
     }
 
     @Test
@@ -77,12 +76,12 @@ class FirstPartyIdentityContractTest {
         mockMvc.perform(get("/api/v1/workspace/capabilities")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer missing-scope"))
                 .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.status").value(403))
-                .andExpect(jsonPath("$.error").value("Forbidden"))
+                .andExpect(jsonPath("$.code").value("forbidden"))
                 .andExpect(jsonPath("$.message").value(
                         "The bearer token is authenticated but missing the required weave:workspace scope."))
-                .andExpect(jsonPath("$.path").value(endsWith("/api/v1/workspace/capabilities")))
-                .andExpect(jsonPath("$.timestamp").value(not(emptyOrNullString())));
+                .andExpect(jsonPath("$.details.status").value(403))
+                .andExpect(jsonPath("$.details.path").value(endsWith("/api/v1/workspace/capabilities")))
+                .andExpect(jsonPath("$.requestId").value(notNullValue()));
     }
 
     @ParameterizedTest
@@ -110,7 +109,8 @@ class FirstPartyIdentityContractTest {
         mockMvc.perform(get("/api/v1/me")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer client-id-only"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.issuedFor").value(FIRST_PARTY_CLIENT_ID));
+                .andExpect(jsonPath("$.issuedFor").value(FIRST_PARTY_CLIENT_ID))
+                .andExpect(jsonPath("$.userId").value("user-123"));
     }
 
     @Test
@@ -118,8 +118,10 @@ class FirstPartyIdentityContractTest {
         mockMvc.perform(get("/api/v1/me")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer valid-full-token"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.sub").value("user-123"))
-                .andExpect(jsonPath("$.preferredUsername").value("alice"))
+                .andExpect(jsonPath("$.userId").value("user-123"))
+                .andExpect(jsonPath("$.username").value("alice"))
+                .andExpect(jsonPath("$.emailVerified").value(false))
+                .andExpect(jsonPath("$.displayName").value("Alice Example"))
                 .andExpect(jsonPath("$.issuedFor").value(FIRST_PARTY_CLIENT_ID))
                 .andExpect(jsonPath("$.audience[0]").value(REQUIRED_AUDIENCE))
                 .andExpect(jsonPath("$.realmRoles[0]").value("member"));

--- a/src/test/java/com/massimotter/weave/backend/config/MissingIssuerRuntimeContractTest.java
+++ b/src/test/java/com/massimotter/weave/backend/config/MissingIssuerRuntimeContractTest.java
@@ -24,9 +24,10 @@ class MissingIssuerRuntimeContractTest {
                 .andExpect(status().isOk());
 
         mockMvc.perform(get("/api/v1/me")
-                        .header(AUTHORIZATION, "Bearer invalid-without-issuer"))
+                .header(AUTHORIZATION, "Bearer invalid-without-issuer"))
                 .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.error").value("Unauthorized"))
+                .andExpect(jsonPath("$.code").value("unauthorized"))
+                .andExpect(jsonPath("$.details.status").value(401))
                 .andExpect(jsonPath("$.message").value(
                         "Bearer authentication is required and must satisfy the first-party Weave token contract."));
     }

--- a/src/test/java/com/massimotter/weave/backend/controller/IdentityControllerTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/IdentityControllerTest.java
@@ -43,18 +43,44 @@ class IdentityControllerTest {
                         .claim("preferred_username", "alice")
                         .claim("name", "Alice Example")
                         .claim("email", "alice@example.com")
+                        .claim("email_verified", true)
+                        .claim("locale", "en")
+                        .claim("timezone", "Europe/Berlin")
                         .claim("azp", "weave-app")
                         .claim("aud", List.of("weave-app", "account"))
                         .claim("realm_access", Map.of("roles", List.of("member", "admin")))
                         .claim("groups", List.of("team-alpha", "team-beta")))
                         .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value("user-123"))
+                .andExpect(jsonPath("$.username").value("alice"))
+                .andExpect(jsonPath("$.displayName").value("Alice Example"))
+                .andExpect(jsonPath("$.emailVerified").value(true))
+                .andExpect(jsonPath("$.timezone").value("Europe/Berlin"))
+                .andExpect(jsonPath("$.roles[0]").value("admin"))
+                .andExpect(jsonPath("$.moduleSyncStatus.matrix").value("not_configured"))
                 .andExpect(jsonPath("$.sub").value("user-123"))
                 .andExpect(jsonPath("$.preferredUsername").value("alice"))
                 .andExpect(jsonPath("$.issuedFor").value("weave-app"))
                 .andExpect(jsonPath("$.audience[0]").value("weave-app"))
                 .andExpect(jsonPath("$.realmRoles[0]").value("admin"))
                 .andExpect(jsonPath("$.groups[1]").value("team-beta"));
+    }
+
+    @Test
+    void exposesCanonicalMeEndpoint() throws Exception {
+        mockMvc.perform(get("/api/me").with(jwt().jwt(jwt -> jwt
+                        .subject("user-123")
+                        .claim("preferred_username", "alice")
+                        .claim("name", "Alice Example")
+                        .claim("email", "alice@example.com")
+                        .claim("aud", List.of("weave-app")))
+                        .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value("user-123"))
+                .andExpect(jsonPath("$.username").value("alice"))
+                .andExpect(jsonPath("$.email").value("alice@example.com"))
+                .andExpect(jsonPath("$.displayName").value("Alice Example"));
     }
 
     @Test

--- a/src/test/java/com/massimotter/weave/backend/controller/OpenApiDocumentationTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/OpenApiDocumentationTest.java
@@ -31,11 +31,17 @@ class OpenApiDocumentationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.openapi").value(startsWith("3.")))
                 .andExpect(jsonPath("$.info.title").value("Weave Backend API"))
+                .andExpect(jsonPath("$.paths['/api/me']").exists())
+                .andExpect(jsonPath("$.paths['/api/health/live']").exists())
+                .andExpect(jsonPath("$.paths['/api/health/ready']").exists())
+                .andExpect(jsonPath("$.paths['/api/platform/config']").exists())
+                .andExpect(jsonPath("$.paths['/api/platform/status']").exists())
                 .andExpect(jsonPath("$.paths['/api/v1/me']").exists())
                 .andExpect(jsonPath("$.paths['/api/v1/workspace/capabilities']").exists())
                 .andExpect(jsonPath("$.paths['/api/v1/workspace/release-readiness']").exists())
-                .andExpect(jsonPath("$.components.schemas.ApiErrorResponse.properties.status.type").value("integer"))
+                .andExpect(jsonPath("$.components.schemas.ApiErrorResponse.properties.code.type").value("string"))
                 .andExpect(jsonPath("$.components.schemas.ApiErrorResponse.properties.message.type").value("string"))
+                .andExpect(jsonPath("$.components.schemas.ApiErrorResponse.properties.requestId.type").value("string"))
                 .andExpect(jsonPath("$.components.responses.UnauthorizedError.description").value("Missing or invalid bearer token."))
                 .andExpect(jsonPath("$.components.securitySchemes['bearer-jwt'].type").value("http"));
     }

--- a/src/test/java/com/massimotter/weave/backend/controller/PlatformControllerTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/PlatformControllerTest.java
@@ -1,0 +1,102 @@
+package com.massimotter.weave.backend.controller;
+
+import com.massimotter.weave.backend.config.ApiAccessDeniedHandler;
+import com.massimotter.weave.backend.config.ApiAuthenticationEntryPoint;
+import com.massimotter.weave.backend.config.ApiErrorResponseWriter;
+import com.massimotter.weave.backend.config.PlatformContractProperties;
+import com.massimotter.weave.backend.config.SecurityConfig;
+import com.massimotter.weave.backend.config.WeaveSecurityProperties;
+import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
+import com.massimotter.weave.backend.service.PlatformContractService;
+import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = {PlatformController.class, HealthController.class},
+        excludeAutoConfiguration = OAuth2ResourceServerAutoConfiguration.class)
+@Import({
+        SecurityConfig.class,
+        PlatformContractService.class,
+        WorkspaceCapabilityService.class,
+        ApiAuthenticationEntryPoint.class,
+        ApiAccessDeniedHandler.class,
+        ApiErrorResponseWriter.class
+})
+@EnableConfigurationProperties({
+        PlatformContractProperties.class,
+        WeaveSecurityProperties.class,
+        WorkspaceCapabilityProperties.class,
+        OAuth2ResourceServerProperties.class
+})
+@TestPropertySource(properties = {
+        "spring.security.oauth2.resourceserver.jwt.issuer-uri=https://auth.weave.local/realms/weave",
+        "weave.workspace.chat.dependency-url=https://matrix.weave.local",
+        "weave.workspace.files.dependency-url=https://files.weave.local",
+        "weave.workspace.calendar.enabled=true"
+})
+class PlatformControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JwtDecoder jwtDecoder;
+
+    @Test
+    void exposesPublicPlatformConfig() throws Exception {
+        mockMvc.perform(get("/api/platform/config"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.publicBaseUrl").value("https://weave.local"))
+                .andExpect(jsonPath("$.apiBaseUrl").value("https://weave.local/api"))
+                .andExpect(jsonPath("$.authBaseUrl").value("https://auth.weave.local"))
+                .andExpect(jsonPath("$.matrixBaseUrl").value("https://matrix.weave.local"))
+                .andExpect(jsonPath("$.filesProductUrl").value("https://weave.local/files"))
+                .andExpect(jsonPath("$.calendarProductUrl").value("https://weave.local/calendar"))
+                .andExpect(jsonPath("$.nextcloudRawBaseUrl").value("https://files.weave.local"))
+                .andExpect(jsonPath("$.targets.mobile").value(true))
+                .andExpect(jsonPath("$.targets.desktop").value(true))
+                .andExpect(jsonPath("$.targets.web").value(false))
+                .andExpect(jsonPath("$.features.chat").value(true))
+                .andExpect(jsonPath("$.features.chatE2ee").value(false))
+                .andExpect(jsonPath("$.features.matrixFederation").value(false))
+                .andExpect(jsonPath("$.features.files").value(true))
+                .andExpect(jsonPath("$.features.calendar").value(true));
+    }
+
+    @Test
+    void exposesPublicPlatformStatus() throws Exception {
+        mockMvc.perform(get("/api/platform/status"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.backend.status").value("up"))
+                .andExpect(jsonPath("$.auth.status").value("up"))
+                .andExpect(jsonPath("$.matrix.status").value("up"))
+                .andExpect(jsonPath("$.matrix.federationEnabled").value(false))
+                .andExpect(jsonPath("$.matrix.e2eeEnabled").value(false))
+                .andExpect(jsonPath("$.nextcloud.status").value("up"));
+    }
+
+    @Test
+    void exposesPublicHealthEndpoints() throws Exception {
+        mockMvc.perform(get("/api/health/live"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("up"));
+
+        mockMvc.perform(get("/api/health/ready"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("up"));
+    }
+}

--- a/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
@@ -44,7 +44,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @org.springframework.test.context.TestPropertySource(properties = {
         "spring.security.oauth2.resourceserver.jwt.issuer-uri=https://auth.example.invalid/realms/weave",
         "weave.workspace.chat.dependency-url=https://matrix.weave.local",
-        "weave.workspace.files.dependency-url=https://nextcloud.weave.local",
+        "weave.workspace.files.dependency-url=https://files.weave.local",
         "weave.workspace.calendar.enabled=true",
         "weave.workspace.calendar.readiness=degraded"
 })

--- a/src/test/java/com/massimotter/weave/backend/service/WorkspaceCapabilityServiceTest.java
+++ b/src/test/java/com/massimotter/weave/backend/service/WorkspaceCapabilityServiceTest.java
@@ -34,7 +34,7 @@ class WorkspaceCapabilityServiceTest {
                 new WorkspaceCapabilityProperties(
                         new WorkspaceCapabilityProperties.Capability(true, null, null),
                         new WorkspaceCapabilityProperties.Capability(true, "https://matrix.weave.local", null),
-                        new WorkspaceCapabilityProperties.Capability(true, "https://nextcloud.weave.local", null),
+                        new WorkspaceCapabilityProperties.Capability(true, "https://files.weave.local", null),
                         null,
                         null));
 
@@ -53,7 +53,7 @@ class WorkspaceCapabilityServiceTest {
                 new WorkspaceCapabilityProperties(
                         new WorkspaceCapabilityProperties.Capability(true, null, null),
                         new WorkspaceCapabilityProperties.Capability(true, "https://matrix.weave.local", WorkspaceCapabilityReadiness.DEGRADED),
-                        new WorkspaceCapabilityProperties.Capability(true, "https://nextcloud.weave.local", WorkspaceCapabilityReadiness.BLOCKED),
+                        new WorkspaceCapabilityProperties.Capability(true, "https://files.weave.local", WorkspaceCapabilityReadiness.BLOCKED),
                         new WorkspaceCapabilityProperties.Capability(true, null, WorkspaceCapabilityReadiness.READY),
                         new WorkspaceCapabilityProperties.Capability(false, null, WorkspaceCapabilityReadiness.READY)));
 
@@ -73,7 +73,7 @@ class WorkspaceCapabilityServiceTest {
                 new WorkspaceCapabilityProperties(
                         new WorkspaceCapabilityProperties.Capability(false, null, null),
                         new WorkspaceCapabilityProperties.Capability(true, "https://matrix.weave.local", null),
-                        new WorkspaceCapabilityProperties.Capability(true, "https://nextcloud.weave.local", null),
+                        new WorkspaceCapabilityProperties.Capability(true, "https://files.weave.local", null),
                         null,
                         null));
 

--- a/src/test/java/com/massimotter/weave/backend/service/WorkspaceReleaseReadinessServiceTest.java
+++ b/src/test/java/com/massimotter/weave/backend/service/WorkspaceReleaseReadinessServiceTest.java
@@ -18,7 +18,7 @@ class WorkspaceReleaseReadinessServiceTest {
                 new WorkspaceCapabilityProperties(
                         new WorkspaceCapabilityProperties.Capability(true, null, null),
                         new WorkspaceCapabilityProperties.Capability(true, "https://matrix.weave.local", null),
-                        new WorkspaceCapabilityProperties.Capability(true, "https://nextcloud.weave.local", null),
+                        new WorkspaceCapabilityProperties.Capability(true, "https://files.weave.local", null),
                         null,
                         null));
 
@@ -28,7 +28,7 @@ class WorkspaceReleaseReadinessServiceTest {
                 new WorkspaceCapabilityProperties(
                         new WorkspaceCapabilityProperties.Capability(true, null, null),
                         new WorkspaceCapabilityProperties.Capability(true, "https://matrix.weave.local", null),
-                        new WorkspaceCapabilityProperties.Capability(true, "https://nextcloud.weave.local", null),
+                        new WorkspaceCapabilityProperties.Capability(true, "https://files.weave.local", null),
                         null,
                         null),
                 capabilityService);
@@ -90,7 +90,7 @@ class WorkspaceReleaseReadinessServiceTest {
         assertThat(snapshot.readiness()).isEqualTo(WorkspaceCapabilityReadiness.DEGRADED);
         assertThat(snapshot.actions()).containsExactly(
                 "Set WEAVE_MATRIX_HOMESERVER_URL to the public Matrix base URL, for example https://matrix.weave.local.",
-                "Set WEAVE_NEXTCLOUD_BASE_URL to the public Nextcloud base URL, for example https://nextcloud.weave.local.");
+                "Set WEAVE_NEXTCLOUD_BASE_URL to the raw Nextcloud fallback URL, for example https://files.weave.local.");
     }
 
     private OAuth2ResourceServerProperties resourceServerProperties(String issuerUri) {


### PR DESCRIPTION
## Summary
- Add public /api/health/live, /api/health/ready, /api/platform/config, and /api/platform/status endpoints.
- Make /api/me the canonical authenticated profile endpoint while retaining /api/v1/me compatibility.
- Add final local topology defaults, module status/config responses, request-id error envelopes, and OpenAPI/test coverage.

## Why
This is the backend slice of the cross-repo platform-contract baseline from the final Weave specs. It gives the client and infra a stable product API surface before deeper profile, files, and calendar facades are implemented.

## Validation
- ./gradlew --no-daemon test
- ./gradlew --no-daemon check
- git diff --check