### PR TITLE
feat: add Nextcloud files facade adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The backend should act as a product API and orchestration layer, not as a blind 
 
 - validating access tokens from Weave clients
 - exposing product-specific REST APIs and normalized errors
-- exposing Files and Calendar facade contracts before downstream Nextcloud adapter wiring is complete
+- exposing Files and Calendar facade contracts, with Files backed by a fail-closed Nextcloud WebDAV adapter when backend-owned actor credentials are configured
 - orchestrating server-owned workflows across Keycloak, Matrix, and Nextcloud
 - running automation, provisioning, and background jobs
 
@@ -19,7 +19,7 @@ This repository now starts as a JWT-protected Spring Boot API with:
 - a canonical `/api/me` endpoint for profile claim inspection and client/backend contract testing
 - a `/api/v1/workspace/capabilities` endpoint for the first backend-owned client contract
 - a `/api/v1/workspace/release-readiness` endpoint for operator-facing Release 1 setup status and remaining actions
-- authenticated Files facade endpoints at `/api/files`, `/api/files/upload`, `/api/files/folders`, and `/api/files/{id}/download`
+- authenticated Files facade endpoints at `/api/files`, `/api/files/upload`, `/api/files/folders`, `/api/files/{id}/download`, and `/api/files/{id}` backed by Nextcloud WebDAV when configured
 - authenticated Calendar facade endpoints at `/api/calendar/events` and `/api/calendar/events/{id}`
 - OpenAPI JSON published at `/v3/api-docs`
 - actuator health and info endpoints
@@ -51,7 +51,7 @@ Optional runtime variables:
 - `WEAVE_MATRIX_HOMESERVER_URL`: public Matrix base URL used by chat auto-readiness
 - `WEAVE_WORKSPACE_CHAT_READINESS`: optional explicit chat readiness override (`ready`, `degraded`, `blocked`, `unavailable`)
 - `WEAVE_WORKSPACE_FILES_ENABLED`: enable files in the workspace snapshot, defaults to `true`
-- `WEAVE_NEXTCLOUD_BASE_URL`: canonical Nextcloud URL used by files auto-readiness
+- `WEAVE_NEXTCLOUD_BASE_URL`: canonical Nextcloud URL used by files auto-readiness and the backend Files adapter
 - `WEAVE_WORKSPACE_FILES_READINESS`: optional explicit files readiness override (`ready`, `degraded`, `blocked`, `unavailable`)
 - `WEAVE_WORKSPACE_CALENDAR_ENABLED`: enable the calendar capability, defaults to `false`
 - `WEAVE_WORKSPACE_CALENDAR_READINESS`: optional explicit calendar readiness override (`ready`, `degraded`, `blocked`, `unavailable`)
@@ -64,7 +64,20 @@ Optional runtime variables:
 - `WEAVE_FILES_PRODUCT_URL`: public files product surface, defaults to `https://weave.local/files`
 - `WEAVE_CALENDAR_PRODUCT_URL`: public calendar product surface, defaults to `https://weave.local/calendar`
 - `WEAVE_NEXTCLOUD_BASE_URL`: canonical Nextcloud URL, defaults to `https://files.weave.local`
+- `WEAVE_NEXTCLOUD_FILES_ACTOR_MODEL`: backend-to-Nextcloud token model, currently only `backend-service-account`; other values fail closed until implemented
+- `WEAVE_NEXTCLOUD_FILES_ACTOR_USERNAME`: backend-owned Nextcloud actor username for WebDAV calls; blank keeps the facade unavailable instead of forwarding caller tokens
+- `WEAVE_NEXTCLOUD_FILES_ACTOR_TOKEN`: backend-owned Nextcloud app password/token for WebDAV calls; blank keeps the facade unavailable
+- `WEAVE_NEXTCLOUD_FILES_APP_PASSWORD`: compatibility alias used when `WEAVE_NEXTCLOUD_FILES_ACTOR_TOKEN` is blank
+- `WEAVE_NEXTCLOUD_FILES_WEBDAV_ROOT_PATH`: Nextcloud WebDAV files root path, defaults to `/remote.php/dav/files`
 - `PORT`: HTTP port, defaults to `8080`
+
+Files adapter behavior:
+
+- The app never receives raw Nextcloud credentials. The backend uses the configured backend-owned actor for WebDAV calls.
+- If the actor model, username, or token is missing, files endpoints fail closed with `nextcloud-adapter-not-configured`.
+- Implemented WebDAV operations: folder listing with quota when returned by Nextcloud, folder creation, upload, download, and delete.
+- Move/share remain intentionally unsupported until product policy and endpoint contracts are specified.
+- No live Nextcloud integration is implied by unit tests; local/live validation still requires a configured `files.weave.local` and backend actor.
 
 Workspace capability source of truth:
 

--- a/src/main/java/com/massimotter/weave/backend/WeaveBackendApplication.java
+++ b/src/main/java/com/massimotter/weave/backend/WeaveBackendApplication.java
@@ -1,5 +1,6 @@
 package com.massimotter.weave.backend;
 
+import com.massimotter.weave.backend.config.NextcloudFilesProperties;
 import com.massimotter.weave.backend.config.PlatformContractProperties;
 import com.massimotter.weave.backend.config.WeaveSecurityProperties;
 import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
@@ -9,6 +10,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 
 @SpringBootApplication
 @EnableConfigurationProperties({
+        NextcloudFilesProperties.class,
         PlatformContractProperties.class,
         WeaveSecurityProperties.class,
         WorkspaceCapabilityProperties.class

--- a/src/main/java/com/massimotter/weave/backend/config/NextcloudFilesProperties.java
+++ b/src/main/java/com/massimotter/weave/backend/config/NextcloudFilesProperties.java
@@ -1,0 +1,69 @@
+package com.massimotter.weave.backend.config;
+
+import java.net.URI;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+
+@ConfigurationProperties(prefix = "weave.nextcloud.files")
+public record NextcloudFilesProperties(
+        String baseUrl,
+        String webdavRootPath,
+        String actorModel,
+        String actorUsername,
+        String actorToken) {
+
+    public NextcloudFilesProperties {
+        baseUrl = defaultIfBlank(baseUrl, "https://files.weave.local");
+        webdavRootPath = normalizeWebdavRootPath(defaultIfBlank(webdavRootPath, "/remote.php/dav/files"));
+        actorModel = defaultIfBlank(actorModel, "backend-service-account");
+        actorUsername = trimToNull(actorUsername);
+        actorToken = trimToNull(actorToken);
+    }
+
+    public boolean isConfigured() {
+        return StringUtils.hasText(baseUrl)
+                && isSupportedActorModel()
+                && StringUtils.hasText(actorUsername)
+                && StringUtils.hasText(actorToken)
+                && isAbsoluteHttpBaseUrl();
+    }
+
+    public boolean isSupportedActorModel() {
+        return "backend-service-account".equals(actorModel);
+    }
+
+    public URI baseUri() {
+        return URI.create(baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl);
+    }
+
+    private boolean isAbsoluteHttpBaseUrl() {
+        try {
+            URI uri = URI.create(baseUrl);
+            return uri.isAbsolute()
+                    && ("http".equalsIgnoreCase(uri.getScheme()) || "https".equalsIgnoreCase(uri.getScheme()));
+        } catch (IllegalArgumentException exception) {
+            return false;
+        }
+    }
+
+    private static String normalizeWebdavRootPath(String value) {
+        String trimmed = value.trim();
+        String withLeadingSlash = trimmed.startsWith("/") ? trimmed : "/" + trimmed;
+        if (withLeadingSlash.length() > 1 && withLeadingSlash.endsWith("/")) {
+            return withLeadingSlash.substring(0, withLeadingSlash.length() - 1);
+        }
+        return withLeadingSlash;
+    }
+
+    private static String defaultIfBlank(String value, String fallback) {
+        String trimmed = trimToNull(value);
+        return trimmed == null ? fallback : trimmed;
+    }
+
+    private static String trimToNull(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.trim();
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/controller/FilesController.java
+++ b/src/main/java/com/massimotter/weave/backend/controller/FilesController.java
@@ -6,6 +6,7 @@ import com.massimotter.weave.backend.model.files.FileItemResponse;
 import com.massimotter.weave.backend.model.files.FileListResponse;
 import com.massimotter.weave.backend.model.files.FileUploadResponse;
 import com.massimotter.weave.backend.service.FilesFacadeService;
+import com.massimotter.weave.backend.service.files.DownloadedFile;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -16,6 +17,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -84,9 +87,13 @@ public class FilesController {
 
     @GetMapping("/api/files/{id}/download")
     @Operation(summary = "Download a file")
-    public ResponseEntity<Void> download(@PathVariable @Size(max = 2048) String id) {
-        filesFacadeService.prepareDownload(id);
-        return ResponseEntity.noContent().build();
+    public ResponseEntity<byte[]> download(@PathVariable @Size(max = 2048) String id) {
+        DownloadedFile file = filesFacadeService.download(id);
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType(file.mimeType()))
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        ContentDisposition.attachment().filename(file.filename()).build().toString())
+                .body(file.content());
     }
 
     @DeleteMapping("/api/files/{id}")

--- a/src/main/java/com/massimotter/weave/backend/service/FilesFacadeService.java
+++ b/src/main/java/com/massimotter/weave/backend/service/FilesFacadeService.java
@@ -5,7 +5,10 @@ import com.massimotter.weave.backend.model.files.CreateFolderRequest;
 import com.massimotter.weave.backend.model.files.FileItemResponse;
 import com.massimotter.weave.backend.model.files.FileListResponse;
 import com.massimotter.weave.backend.model.files.FileUploadResponse;
+import com.massimotter.weave.backend.service.files.DownloadedFile;
+import com.massimotter.weave.backend.service.files.FilesStorageAdapter;
 import java.util.Map;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -13,24 +16,37 @@ import org.springframework.web.multipart.MultipartFile;
 @Service
 public class FilesFacadeService {
 
+    private final FilesStorageAdapter filesStorageAdapter;
+
+    public FilesFacadeService(ObjectProvider<FilesStorageAdapter> filesStorageAdapterProvider) {
+        this.filesStorageAdapter = filesStorageAdapterProvider.getIfAvailable();
+    }
+
     public FileListResponse list(String path) {
-        throw adapterNotConfigured("list-files");
+        return configuredAdapter("list-files").list(path);
     }
 
     public FileItemResponse createFolder(CreateFolderRequest request) {
-        throw adapterNotConfigured("create-folder");
+        return configuredAdapter("create-folder").createFolder(request);
     }
 
     public FileUploadResponse upload(String parentPath, MultipartFile file) {
-        throw adapterNotConfigured("upload-file");
+        return configuredAdapter("upload-file").upload(parentPath, file);
     }
 
-    public void prepareDownload(String id) {
-        throw adapterNotConfigured("download-file");
+    public DownloadedFile download(String id) {
+        return configuredAdapter("download-file").download(id);
     }
 
     public void delete(String id) {
-        throw adapterNotConfigured("delete-file");
+        configuredAdapter("delete-file").delete(id);
+    }
+
+    private FilesStorageAdapter configuredAdapter(String operation) {
+        if (filesStorageAdapter == null || !filesStorageAdapter.isConfigured()) {
+            throw adapterNotConfigured(operation);
+        }
+        return filesStorageAdapter;
     }
 
     private ApiErrorException adapterNotConfigured(String operation) {

--- a/src/main/java/com/massimotter/weave/backend/service/files/DownloadedFile.java
+++ b/src/main/java/com/massimotter/weave/backend/service/files/DownloadedFile.java
@@ -1,0 +1,4 @@
+package com.massimotter.weave.backend.service.files;
+
+public record DownloadedFile(String filename, String mimeType, byte[] content) {
+}

--- a/src/main/java/com/massimotter/weave/backend/service/files/FilePathCodec.java
+++ b/src/main/java/com/massimotter/weave/backend/service/files/FilePathCodec.java
@@ -1,0 +1,113 @@
+package com.massimotter.weave.backend.service.files;
+
+import com.massimotter.weave.backend.exception.ApiErrorException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.util.UriUtils;
+
+final class FilePathCodec {
+
+    private static final String ID_PREFIX = "files:";
+
+    private FilePathCodec() {
+    }
+
+    static String toId(String normalizedPath) {
+        String encoded = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(normalizedPath.getBytes(StandardCharsets.UTF_8));
+        return ID_PREFIX + encoded;
+    }
+
+    static String pathFromId(String id) {
+        if (id == null || id.isBlank()) {
+            throw invalidPath("File identifier is required.");
+        }
+        String trimmed = id.trim();
+        if (trimmed.startsWith(ID_PREFIX)) {
+            String encoded = trimmed.substring(ID_PREFIX.length());
+            try {
+                return normalizeProductPath(new String(Base64.getUrlDecoder().decode(encoded), StandardCharsets.UTF_8));
+            } catch (IllegalArgumentException exception) {
+                throw invalidPath("File identifier is not valid.");
+            }
+        }
+        if (trimmed.startsWith("/")) {
+            return normalizeProductPath(trimmed);
+        }
+        throw invalidPath("File identifier is not valid.");
+    }
+
+    static String normalizeProductPath(String path) {
+        if (path == null || path.isBlank()) {
+            throw invalidPath("Path is required.");
+        }
+        String normalized = path.trim().replaceAll("/{2,}", "/");
+        if (!normalized.startsWith("/")) {
+            throw invalidPath("Path must start with /.");
+        }
+        if (normalized.length() > 1 && normalized.endsWith("/")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        if (normalized.indexOf('\0') >= 0 || normalized.contains("\\")) {
+            throw invalidPath("Path contains unsupported characters.");
+        }
+        for (String segment : segments(normalized)) {
+            validatePathSegment(segment, "Path contains unsupported segments.");
+        }
+        return normalized;
+    }
+
+    static String validateFileName(String name) {
+        if (name == null || name.isBlank()) {
+            throw invalidPath("File name is required.");
+        }
+        String trimmed = name.trim();
+        validatePathSegment(trimmed, "File name contains unsupported characters.");
+        return trimmed;
+    }
+
+    static String childPath(String parentPath, String name) {
+        String parent = normalizeProductPath(parentPath);
+        String childName = validateFileName(name);
+        return "/".equals(parent) ? "/" + childName : parent + "/" + childName;
+    }
+
+    static String encodeWebdavPath(String normalizedProductPath) {
+        String path = normalizeProductPath(normalizedProductPath);
+        if ("/".equals(path)) {
+            return "";
+        }
+        return Arrays.stream(segments(path))
+                .map(segment -> UriUtils.encodePathSegment(segment, StandardCharsets.UTF_8))
+                .reduce("", (left, right) -> left + "/" + right);
+    }
+
+    private static String[] segments(String normalizedProductPath) {
+        if ("/".equals(normalizedProductPath)) {
+            return new String[0];
+        }
+        return normalizedProductPath.substring(1).split("/");
+    }
+
+    private static void validatePathSegment(String segment, String message) {
+        if (segment.isBlank()
+                || ".".equals(segment)
+                || "..".equals(segment)
+                || segment.contains("/")
+                || segment.contains("\\")
+                || segment.indexOf('\0') >= 0) {
+            throw invalidPath(message);
+        }
+    }
+
+    private static ApiErrorException invalidPath(String message) {
+        return new ApiErrorException(
+                HttpStatus.BAD_REQUEST,
+                "invalid-file-path",
+                message,
+                Map.of("module", "files"));
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/service/files/FilesStorageAdapter.java
+++ b/src/main/java/com/massimotter/weave/backend/service/files/FilesStorageAdapter.java
@@ -1,0 +1,22 @@
+package com.massimotter.weave.backend.service.files;
+
+import com.massimotter.weave.backend.model.files.CreateFolderRequest;
+import com.massimotter.weave.backend.model.files.FileItemResponse;
+import com.massimotter.weave.backend.model.files.FileListResponse;
+import com.massimotter.weave.backend.model.files.FileUploadResponse;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface FilesStorageAdapter {
+
+    boolean isConfigured();
+
+    FileListResponse list(String path);
+
+    FileItemResponse createFolder(CreateFolderRequest request);
+
+    FileUploadResponse upload(String parentPath, MultipartFile file);
+
+    DownloadedFile download(String id);
+
+    void delete(String id);
+}

--- a/src/main/java/com/massimotter/weave/backend/service/files/NextcloudFilesAdapter.java
+++ b/src/main/java/com/massimotter/weave/backend/service/files/NextcloudFilesAdapter.java
@@ -1,0 +1,462 @@
+package com.massimotter.weave.backend.service.files;
+
+import com.massimotter.weave.backend.config.NextcloudFilesProperties;
+import com.massimotter.weave.backend.exception.ApiErrorException;
+import com.massimotter.weave.backend.model.files.CreateFolderRequest;
+import com.massimotter.weave.backend.model.files.FileItemResponse;
+import com.massimotter.weave.backend.model.files.FileListResponse;
+import com.massimotter.weave.backend.model.files.FileQuotaResponse;
+import com.massimotter.weave.backend.model.files.FileUploadResponse;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StreamUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.util.UriUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+@Component
+public class NextcloudFilesAdapter implements FilesStorageAdapter {
+
+    private static final HttpMethod PROPFIND = HttpMethod.valueOf("PROPFIND");
+    private static final HttpMethod MKCOL = HttpMethod.valueOf("MKCOL");
+
+    private static final String PROPFIND_BODY = """
+            <?xml version=\"1.0\" encoding=\"UTF-8\"?>
+            <d:propfind xmlns:d=\"DAV:\">
+              <d:prop>
+                <d:resourcetype />
+                <d:getcontentlength />
+                <d:getcontenttype />
+                <d:getlastmodified />
+                <d:quota-used-bytes />
+                <d:quota-available-bytes />
+              </d:prop>
+            </d:propfind>
+            """;
+
+    private final NextcloudFilesProperties properties;
+    private final RestClient restClient;
+
+    public NextcloudFilesAdapter(NextcloudFilesProperties properties, RestClient.Builder restClientBuilder) {
+        this.properties = properties;
+        this.restClient = restClientBuilder.build();
+    }
+
+    @Override
+    public boolean isConfigured() {
+        return properties.isConfigured();
+    }
+
+    @Override
+    public FileListResponse list(String path) {
+        ensureConfigured();
+        String normalizedPath = FilePathCodec.normalizeProductPath(path);
+        try {
+            return restClient.method(PROPFIND)
+                    .uri(webdavUri(normalizedPath, true))
+                    .headers(this::applyActorHeaders)
+                    .header("Depth", "1")
+                    .contentType(MediaType.APPLICATION_XML)
+                    .body(PROPFIND_BODY)
+                    .exchange((request, response) -> {
+                        if (response.getStatusCode().value() == 207 || response.getStatusCode().is2xxSuccessful()) {
+                            return parseList(normalizedPath, response.getBody());
+                        }
+                        throw mapStatus(response.getStatusCode(), "list-files", normalizedPath);
+                    });
+        } catch (ResourceAccessException exception) {
+            throw downstreamUnavailable("list-files", exception);
+        } catch (RestClientException exception) {
+            throw downstreamFailure("list-files", exception);
+        }
+    }
+
+    @Override
+    public FileItemResponse createFolder(CreateFolderRequest request) {
+        ensureConfigured();
+        String folderPath = FilePathCodec.childPath(request.parentPath(), request.name());
+        try {
+            return restClient.method(MKCOL)
+                    .uri(webdavUri(folderPath, false))
+                    .headers(this::applyActorHeaders)
+                    .exchange((webdavRequest, response) -> {
+                        if (response.getStatusCode().is2xxSuccessful()) {
+                            return folderItem(folderPath, null);
+                        }
+                        throw mapStatus(response.getStatusCode(), "create-folder", folderPath);
+                    });
+        } catch (ResourceAccessException exception) {
+            throw downstreamUnavailable("create-folder", exception);
+        } catch (RestClientException exception) {
+            throw downstreamFailure("create-folder", exception);
+        }
+    }
+
+    @Override
+    public FileUploadResponse upload(String parentPath, MultipartFile file) {
+        ensureConfigured();
+        String filename = FilePathCodec.validateFileName(firstText(file.getOriginalFilename(), file.getName()));
+        String targetPath = FilePathCodec.childPath(parentPath, filename);
+        try {
+            byte[] content = file.getBytes();
+            FileItemResponse item = restClient.method(HttpMethod.PUT)
+                    .uri(webdavUri(targetPath, false))
+                    .headers(headers -> {
+                        applyActorHeaders(headers);
+                        MediaType mediaType = file.getContentType() == null
+                                ? MediaType.APPLICATION_OCTET_STREAM
+                                : MediaType.parseMediaType(file.getContentType());
+                        headers.setContentType(mediaType);
+                    })
+                    .body(content)
+                    .exchange((request, response) -> {
+                        if (response.getStatusCode().is2xxSuccessful()) {
+                            return fileItem(targetPath, file.getContentType(), (long) content.length, null);
+                        }
+                        throw mapStatus(response.getStatusCode(), "upload-file", targetPath);
+                    });
+            return new FileUploadResponse(item);
+        } catch (ApiErrorException exception) {
+            throw exception;
+        } catch (ResourceAccessException exception) {
+            throw downstreamUnavailable("upload-file", exception);
+        } catch (RestClientException exception) {
+            throw downstreamFailure("upload-file", exception);
+        } catch (Exception exception) {
+            throw new ApiErrorException(
+                    HttpStatus.BAD_REQUEST,
+                    "file-upload-unreadable",
+                    "Uploaded file could not be read by the backend.",
+                    Map.of("module", "files", "operation", "upload-file"));
+        }
+    }
+
+    @Override
+    public DownloadedFile download(String id) {
+        ensureConfigured();
+        String path = FilePathCodec.pathFromId(id);
+        try {
+            return restClient.get()
+                    .uri(webdavUri(path, false))
+                    .headers(this::applyActorHeaders)
+                    .exchange((request, response) -> {
+                        if (response.getStatusCode().is2xxSuccessful()) {
+                            byte[] body = StreamUtils.copyToByteArray(response.getBody());
+                            MediaType mediaType = response.getHeaders().getContentType();
+                            return new DownloadedFile(
+                                    filename(path),
+                                    mediaType == null ? MediaType.APPLICATION_OCTET_STREAM_VALUE : mediaType.toString(),
+                                    body);
+                        }
+                        throw mapStatus(response.getStatusCode(), "download-file", path);
+                    });
+        } catch (ResourceAccessException exception) {
+            throw downstreamUnavailable("download-file", exception);
+        } catch (RestClientException exception) {
+            throw downstreamFailure("download-file", exception);
+        }
+    }
+
+    @Override
+    public void delete(String id) {
+        ensureConfigured();
+        String path = FilePathCodec.pathFromId(id);
+        try {
+            restClient.method(HttpMethod.DELETE)
+                    .uri(webdavUri(path, false))
+                    .headers(this::applyActorHeaders)
+                    .exchange((request, response) -> {
+                        if (response.getStatusCode().is2xxSuccessful()) {
+                            return null;
+                        }
+                        throw mapStatus(response.getStatusCode(), "delete-file", path);
+                    });
+        } catch (ResourceAccessException exception) {
+            throw downstreamUnavailable("delete-file", exception);
+        } catch (RestClientException exception) {
+            throw downstreamFailure("delete-file", exception);
+        }
+    }
+
+    private void ensureConfigured() {
+        if (!isConfigured()) {
+            throw new ApiErrorException(
+                    HttpStatus.SERVICE_UNAVAILABLE,
+                    "nextcloud-adapter-not-configured",
+                    "Files facade is available, but the downstream Nextcloud adapter is not configured yet.",
+                    Map.of(
+                            "module", "files",
+                            "actorModel", properties.actorModel(),
+                            "supportedActorModels", List.of("backend-service-account")));
+        }
+    }
+
+    private URI webdavUri(String productPath, boolean trailingSlashForRoot) {
+        String actor = UriUtils.encodePathSegment(properties.actorUsername(), StandardCharsets.UTF_8);
+        StringBuilder builder = new StringBuilder(properties.baseUri().toString())
+                .append(properties.webdavRootPath())
+                .append('/')
+                .append(actor)
+                .append(FilePathCodec.encodeWebdavPath(productPath));
+        if (trailingSlashForRoot && "/".equals(productPath)) {
+            builder.append('/');
+        }
+        return URI.create(builder.toString());
+    }
+
+    private void applyActorHeaders(HttpHeaders headers) {
+        headers.setBasicAuth(properties.actorUsername(), properties.actorToken(), StandardCharsets.UTF_8);
+        headers.set(HttpHeaders.ACCEPT, "application/xml, */*");
+        headers.set("OCS-APIRequest", "true");
+    }
+
+    private FileListResponse parseList(String listedPath, InputStream body) {
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setNamespaceAware(true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            Document document = factory.newDocumentBuilder().parse(body);
+            NodeList responses = document.getElementsByTagNameNS("*", "response");
+            List<FileItemResponse> items = new ArrayList<>();
+            FileQuotaResponse quota = null;
+            for (int index = 0; index < responses.getLength(); index++) {
+                Element response = (Element) responses.item(index);
+                String itemPath = productPathFromHref(firstText(childText(response, "href"), "/"));
+                Element prop = firstElement(response, "prop");
+                if (prop == null) {
+                    continue;
+                }
+                if (FilePathCodec.normalizeProductPath(itemPath).equals(listedPath)) {
+                    quota = quotaFrom(prop);
+                    continue;
+                }
+                boolean folder = firstElement(prop, "collection") != null;
+                Long size = folder ? null : parseLong(childText(prop, "getcontentlength"));
+                String mimeType = folder ? null : childText(prop, "getcontenttype");
+                OffsetDateTime modifiedAt = parseModifiedAt(childText(prop, "getlastmodified"));
+                items.add(folder
+                        ? folderItem(itemPath, modifiedAt)
+                        : fileItem(itemPath, mimeType, size, modifiedAt));
+            }
+            items.sort(Comparator
+                    .comparing((FileItemResponse item) -> "folder".equals(item.type()) ? 0 : 1)
+                    .thenComparing(FileItemResponse::name, String.CASE_INSENSITIVE_ORDER));
+            return new FileListResponse(listedPath, List.copyOf(items), quota);
+        } catch (ApiErrorException exception) {
+            throw exception;
+        } catch (Exception exception) {
+            throw new ApiErrorException(
+                    HttpStatus.BAD_GATEWAY,
+                    "nextcloud-response-invalid",
+                    "Nextcloud returned a files response the backend could not parse.",
+                    Map.of("module", "files", "operation", "list-files"));
+        }
+    }
+
+    private FileQuotaResponse quotaFrom(Element prop) {
+        Long used = parseLong(childText(prop, "quota-used-bytes"));
+        Long available = parseLong(childText(prop, "quota-available-bytes"));
+        Long total = used != null && available != null && available >= 0 ? used + available : null;
+        if (used == null && total == null) {
+            return null;
+        }
+        return new FileQuotaResponse(used, total);
+    }
+
+    private String productPathFromHref(String href) {
+        String rawPath = href;
+        try {
+            rawPath = URI.create(href).getRawPath();
+        } catch (IllegalArgumentException ignored) {
+            // Some WebDAV servers return already-decoded relative hrefs. Decode below if possible.
+        }
+        String decodedPath = UriUtils.decode(rawPath, StandardCharsets.UTF_8);
+        String rootPrefix = properties.webdavRootPath() + "/" + properties.actorUsername();
+        String relative = decodedPath.startsWith(rootPrefix)
+                ? decodedPath.substring(rootPrefix.length())
+                : decodedPath;
+        if (relative.isBlank()) {
+            return "/";
+        }
+        if (!relative.startsWith("/")) {
+            relative = "/" + relative;
+        }
+        return FilePathCodec.normalizeProductPath(relative);
+    }
+
+    private FileItemResponse folderItem(String path, OffsetDateTime modifiedAt) {
+        String normalized = FilePathCodec.normalizeProductPath(path);
+        return new FileItemResponse(
+                FilePathCodec.toId(normalized),
+                filename(normalized),
+                normalized,
+                "folder",
+                null,
+                null,
+                modifiedAt,
+                false);
+    }
+
+    private FileItemResponse fileItem(String path, String mimeType, Long size, OffsetDateTime modifiedAt) {
+        String normalized = FilePathCodec.normalizeProductPath(path);
+        return new FileItemResponse(
+                FilePathCodec.toId(normalized),
+                filename(normalized),
+                normalized,
+                "file",
+                mimeType,
+                size,
+                modifiedAt,
+                true);
+    }
+
+    private String filename(String normalizedPath) {
+        if ("/".equals(normalizedPath)) {
+            return "/";
+        }
+        return normalizedPath.substring(normalizedPath.lastIndexOf('/') + 1);
+    }
+
+    private Element firstElement(Element parent, String localName) {
+        NodeList nodes = parent.getElementsByTagNameNS("*", localName);
+        if (nodes.getLength() == 0) {
+            return null;
+        }
+        return (Element) nodes.item(0);
+    }
+
+    private String childText(Element parent, String localName) {
+        Element child = firstElement(parent, localName);
+        if (child == null) {
+            return null;
+        }
+        return child.getTextContent() == null ? null : child.getTextContent().trim();
+    }
+
+    private Long parseLong(String value) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        try {
+            return Long.parseLong(value.trim());
+        } catch (NumberFormatException exception) {
+            return null;
+        }
+    }
+
+    private OffsetDateTime parseModifiedAt(String value) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        try {
+            return ZonedDateTime.parse(value, DateTimeFormatter.RFC_1123_DATE_TIME).toOffsetDateTime();
+        } catch (DateTimeParseException exception) {
+            return null;
+        }
+    }
+
+    private String firstText(String primary, String fallback) {
+        return StringUtils.hasText(primary) ? primary.trim() : fallback;
+    }
+
+    private ApiErrorException mapStatus(HttpStatusCode status, String operation, String path) {
+        int value = status.value();
+        if (value == 401) {
+            return new ApiErrorException(
+                    HttpStatus.SERVICE_UNAVAILABLE,
+                    "nextcloud-auth-failed",
+                    "Files storage authentication failed. Ask an admin to check the backend Nextcloud actor configuration.",
+                    details(operation, path, value));
+        }
+        if (value == 403) {
+            return new ApiErrorException(
+                    HttpStatus.FORBIDDEN,
+                    "files-permission-denied",
+                    "You do not have permission to access this file or folder.",
+                    details(operation, path, value));
+        }
+        if (value == 404) {
+            return new ApiErrorException(
+                    HttpStatus.NOT_FOUND,
+                    "file-not-found",
+                    "The requested file or folder was not found.",
+                    details(operation, path, value));
+        }
+        if (value == 409 || value == 412 || value == 423 || value == 405) {
+            return new ApiErrorException(
+                    HttpStatus.CONFLICT,
+                    "file-conflict",
+                    "The file operation conflicts with the current storage state.",
+                    details(operation, path, value));
+        }
+        if (value == 507) {
+            return new ApiErrorException(
+                    HttpStatus.INSUFFICIENT_STORAGE,
+                    "files-quota-exceeded",
+                    "There is not enough storage available for this file operation.",
+                    details(operation, path, value));
+        }
+        if (value >= 500) {
+            return new ApiErrorException(
+                    HttpStatus.SERVICE_UNAVAILABLE,
+                    "nextcloud-unavailable",
+                    "Files storage is temporarily unavailable.",
+                    details(operation, path, value));
+        }
+        return new ApiErrorException(
+                HttpStatus.BAD_GATEWAY,
+                "nextcloud-request-failed",
+                "Files storage rejected the backend request.",
+                details(operation, path, value));
+    }
+
+    private ApiErrorException downstreamUnavailable(String operation, Exception exception) {
+        return new ApiErrorException(
+                HttpStatus.SERVICE_UNAVAILABLE,
+                "nextcloud-unavailable",
+                "Files storage is temporarily unavailable.",
+                Map.of("module", "files", "operation", operation, "reason", exception.getClass().getSimpleName()));
+    }
+
+    private ApiErrorException downstreamFailure(String operation, Exception exception) {
+        return new ApiErrorException(
+                HttpStatus.BAD_GATEWAY,
+                "nextcloud-request-failed",
+                "Files storage request failed before it could be completed.",
+                Map.of("module", "files", "operation", operation, "reason", exception.getClass().getSimpleName()));
+    }
+
+    private Map<String, Object> details(String operation, String path, int downstreamStatus) {
+        return Map.of(
+                "module", "files",
+                "operation", operation,
+                "path", path,
+                "downstreamStatus", downstreamStatus);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,6 +44,15 @@ weave:
     required-audience: ${WEAVE_OIDC_REQUIRED_AUDIENCE:weave-app}
     # JWT azp and/or client_id must identify the first-party Weave app client.
     client-id: ${WEAVE_CLIENT_ID:weave-app}
+  nextcloud:
+    files:
+      base-url: ${WEAVE_NEXTCLOUD_BASE_URL:https://files.weave.local}
+      webdav-root-path: ${WEAVE_NEXTCLOUD_FILES_WEBDAV_ROOT_PATH:/remote.php/dav/files}
+      # MVP backend-owned actor seam. Leave username/token blank to fail closed with
+      # nextcloud-adapter-not-configured instead of exposing caller credentials.
+      actor-model: ${WEAVE_NEXTCLOUD_FILES_ACTOR_MODEL:backend-service-account}
+      actor-username: ${WEAVE_NEXTCLOUD_FILES_ACTOR_USERNAME:}
+      actor-token: ${WEAVE_NEXTCLOUD_FILES_ACTOR_TOKEN:${WEAVE_NEXTCLOUD_FILES_APP_PASSWORD:}}
   workspace:
     shell-access:
       enabled: ${WEAVE_WORKSPACE_SHELL_ACCESS_ENABLED:true}

--- a/src/test/java/com/massimotter/weave/backend/controller/FilesControllerDownloadTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/FilesControllerDownloadTest.java
@@ -1,0 +1,65 @@
+package com.massimotter.weave.backend.controller;
+
+import com.massimotter.weave.backend.config.ApiAccessDeniedHandler;
+import com.massimotter.weave.backend.config.ApiAuthenticationEntryPoint;
+import com.massimotter.weave.backend.config.ApiErrorResponseWriter;
+import com.massimotter.weave.backend.config.SecurityConfig;
+import com.massimotter.weave.backend.exception.ApiExceptionHandler;
+import com.massimotter.weave.backend.service.FilesFacadeService;
+import com.massimotter.weave.backend.service.files.DownloadedFile;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = FilesController.class,
+        excludeAutoConfiguration = OAuth2ResourceServerAutoConfiguration.class)
+@Import({
+        SecurityConfig.class,
+        ApiAuthenticationEntryPoint.class,
+        ApiAccessDeniedHandler.class,
+        ApiErrorResponseWriter.class,
+        ApiExceptionHandler.class
+})
+@TestPropertySource(properties = {
+        "spring.security.oauth2.resourceserver.jwt.issuer-uri=https://auth.example.invalid/realms/weave"
+})
+class FilesControllerDownloadTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private FilesFacadeService filesFacadeService;
+
+    @MockBean
+    private JwtDecoder jwtDecoder;
+
+    @Test
+    void downloadReturnsFileBytesWithoutExposingNextcloudCredentials() throws Exception {
+        given(filesFacadeService.download("files:test-id"))
+                .willReturn(new DownloadedFile("readme.md", "text/markdown", "hello".getBytes()));
+
+        mockMvc.perform(get("/api/files/files:test-id/download")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"readme.md\""))
+                .andExpect(content().contentType("text/markdown"))
+                .andExpect(content().bytes("hello".getBytes()));
+    }
+}

--- a/src/test/java/com/massimotter/weave/backend/controller/OpenApiDocumentationTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/OpenApiDocumentationTest.java
@@ -40,6 +40,7 @@ class OpenApiDocumentationTest {
                 .andExpect(jsonPath("$.paths['/api/files/upload']").exists())
                 .andExpect(jsonPath("$.paths['/api/files/folders']").exists())
                 .andExpect(jsonPath("$.paths['/api/files/{id}/download']").exists())
+                .andExpect(jsonPath("$.paths['/api/files/{id}']").exists())
                 .andExpect(jsonPath("$.paths['/api/calendar/events']").exists())
                 .andExpect(jsonPath("$.paths['/api/calendar/events/{id}']").exists())
                 .andExpect(jsonPath("$.paths['/api/v1/workspace/capabilities']").exists())

--- a/src/test/java/com/massimotter/weave/backend/service/FilesFacadeServiceTest.java
+++ b/src/test/java/com/massimotter/weave/backend/service/FilesFacadeServiceTest.java
@@ -1,0 +1,124 @@
+package com.massimotter.weave.backend.service;
+
+import com.massimotter.weave.backend.exception.ApiErrorException;
+import com.massimotter.weave.backend.model.files.CreateFolderRequest;
+import com.massimotter.weave.backend.model.files.FileItemResponse;
+import com.massimotter.weave.backend.model.files.FileListResponse;
+import com.massimotter.weave.backend.model.files.FileUploadResponse;
+import com.massimotter.weave.backend.service.files.DownloadedFile;
+import com.massimotter.weave.backend.service.files.FilesStorageAdapter;
+import java.time.OffsetDateTime;
+import java.util.Iterator;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.multipart.MultipartFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class FilesFacadeServiceTest {
+
+    @Test
+    void failsClosedWhenAdapterIsMissingOrUnconfigured() {
+        FilesFacadeService missing = new FilesFacadeService(provider(null));
+        FilesFacadeService unconfigured = new FilesFacadeService(provider(new StubAdapter(false)));
+
+        assertThatThrownBy(() -> missing.list("/"))
+                .isInstanceOfSatisfying(ApiErrorException.class, exception -> {
+                    assertThat(exception.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+                    assertThat(exception.code()).isEqualTo("nextcloud-adapter-not-configured");
+                    assertThat(exception.details()).containsEntry("operation", "list-files");
+                });
+        assertThatThrownBy(() -> unconfigured.upload("/", null))
+                .isInstanceOfSatisfying(ApiErrorException.class, exception ->
+                        assertThat(exception.details()).containsEntry("operation", "upload-file"));
+    }
+
+    @Test
+    void delegatesToConfiguredStorageAdapter() {
+        FilesFacadeService service = new FilesFacadeService(provider(new StubAdapter(true)));
+
+        FileListResponse response = service.list("/Team");
+
+        assertThat(response.path()).isEqualTo("/Team");
+        assertThat(response.items()).extracting(FileItemResponse::name).containsExactly("readme.md");
+    }
+
+    private ObjectProvider<FilesStorageAdapter> provider(FilesStorageAdapter adapter) {
+        return new ObjectProvider<>() {
+            @Override
+            public FilesStorageAdapter getObject(Object... args) {
+                return adapter;
+            }
+
+            @Override
+            public FilesStorageAdapter getIfAvailable() {
+                return adapter;
+            }
+
+            @Override
+            public FilesStorageAdapter getIfUnique() {
+                return adapter;
+            }
+
+            @Override
+            public FilesStorageAdapter getObject() {
+                return adapter;
+            }
+
+            @Override
+            public Iterator<FilesStorageAdapter> iterator() {
+                return adapter == null ? List.<FilesStorageAdapter>of().iterator() : List.of(adapter).iterator();
+            }
+        };
+    }
+
+    private static final class StubAdapter implements FilesStorageAdapter {
+
+        private final boolean configured;
+
+        private StubAdapter(boolean configured) {
+            this.configured = configured;
+        }
+
+        @Override
+        public boolean isConfigured() {
+            return configured;
+        }
+
+        @Override
+        public FileListResponse list(String path) {
+            return new FileListResponse(path, List.of(new FileItemResponse(
+                    "files:test",
+                    "readme.md",
+                    path + "/readme.md",
+                    "file",
+                    "text/markdown",
+                    12L,
+                    OffsetDateTime.parse("2026-04-26T08:00:00Z"),
+                    true)), null);
+        }
+
+        @Override
+        public FileItemResponse createFolder(CreateFolderRequest request) {
+            throw new UnsupportedOperationException("not needed");
+        }
+
+        @Override
+        public FileUploadResponse upload(String parentPath, MultipartFile file) {
+            throw new UnsupportedOperationException("not needed");
+        }
+
+        @Override
+        public DownloadedFile download(String id) {
+            throw new UnsupportedOperationException("not needed");
+        }
+
+        @Override
+        public void delete(String id) {
+            throw new UnsupportedOperationException("not needed");
+        }
+    }
+}

--- a/src/test/java/com/massimotter/weave/backend/service/files/NextcloudFilesAdapterTest.java
+++ b/src/test/java/com/massimotter/weave/backend/service/files/NextcloudFilesAdapterTest.java
@@ -1,0 +1,171 @@
+package com.massimotter.weave.backend.service.files;
+
+import com.massimotter.weave.backend.config.NextcloudFilesProperties;
+import com.massimotter.weave.backend.exception.ApiErrorException;
+import com.massimotter.weave.backend.model.files.CreateFolderRequest;
+import com.massimotter.weave.backend.model.files.FileListResponse;
+import com.massimotter.weave.backend.model.files.FileUploadResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+class NextcloudFilesAdapterTest {
+
+    private static final String AUTH_HEADER = "Basic " + Base64.getEncoder()
+            .encodeToString("weave-service:app-password".getBytes(StandardCharsets.UTF_8));
+
+    private MockRestServiceServer server;
+    private NextcloudFilesAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        RestClient.Builder builder = RestClient.builder();
+        server = MockRestServiceServer.bindTo(builder).build();
+        adapter = new NextcloudFilesAdapter(configuredProperties(), builder);
+    }
+
+    @Test
+    void remainsUnconfiguredUntilBackendActorCredentialsArePresent() {
+        NextcloudFilesAdapter unconfigured = new NextcloudFilesAdapter(
+                new NextcloudFilesProperties(
+                        "https://files.weave.local",
+                        "/remote.php/dav/files",
+                        "backend-service-account",
+                        "",
+                        ""),
+                RestClient.builder());
+
+        assertThat(unconfigured.isConfigured()).isFalse();
+    }
+
+    @Test
+    void listsFolderContentsAndQuotaFromWebdavPropfind() {
+        server.expect(requestTo("https://files.example.test/remote.php/dav/files/weave-service/Team"))
+                .andExpect(method(HttpMethod.valueOf("PROPFIND")))
+                .andExpect(header(HttpHeaders.AUTHORIZATION, AUTH_HEADER))
+                .andExpect(header("Depth", "1"))
+                .andRespond(withStatus(HttpStatus.MULTI_STATUS)
+                        .contentType(MediaType.APPLICATION_XML)
+                        .body("""
+                                <?xml version=\"1.0\" encoding=\"utf-8\" ?>
+                                <d:multistatus xmlns:d=\"DAV:\">
+                                  <d:response>
+                                    <d:href>/remote.php/dav/files/weave-service/Team/</d:href>
+                                    <d:propstat><d:prop>
+                                      <d:resourcetype><d:collection /></d:resourcetype>
+                                      <d:quota-used-bytes>10</d:quota-used-bytes>
+                                      <d:quota-available-bytes>90</d:quota-available-bytes>
+                                    </d:prop></d:propstat>
+                                  </d:response>
+                                  <d:response>
+                                    <d:href>/remote.php/dav/files/weave-service/Team/Design/</d:href>
+                                    <d:propstat><d:prop>
+                                      <d:resourcetype><d:collection /></d:resourcetype>
+                                      <d:getlastmodified>Sun, 26 Apr 2026 08:00:00 GMT</d:getlastmodified>
+                                    </d:prop></d:propstat>
+                                  </d:response>
+                                  <d:response>
+                                    <d:href>/remote.php/dav/files/weave-service/Team/readme%20one.md</d:href>
+                                    <d:propstat><d:prop>
+                                      <d:resourcetype />
+                                      <d:getcontentlength>12</d:getcontentlength>
+                                      <d:getcontenttype>text/markdown</d:getcontenttype>
+                                      <d:getlastmodified>Sun, 26 Apr 2026 08:01:00 GMT</d:getlastmodified>
+                                    </d:prop></d:propstat>
+                                  </d:response>
+                                </d:multistatus>
+                                """));
+
+        FileListResponse response = adapter.list("/Team/");
+
+        assertThat(response.path()).isEqualTo("/Team");
+        assertThat(response.quota().usedBytes()).isEqualTo(10);
+        assertThat(response.quota().totalBytes()).isEqualTo(100);
+        assertThat(response.items()).hasSize(2);
+        assertThat(response.items().get(0).type()).isEqualTo("folder");
+        assertThat(response.items().get(0).path()).isEqualTo("/Team/Design");
+        assertThat(response.items().get(0).downloadable()).isFalse();
+        assertThat(response.items().get(1).type()).isEqualTo("file");
+        assertThat(response.items().get(1).name()).isEqualTo("readme one.md");
+        assertThat(response.items().get(1).mimeType()).isEqualTo("text/markdown");
+        assertThat(response.items().get(1).size()).isEqualTo(12);
+        assertThat(response.items().get(1).id()).startsWith("files:");
+        server.verify();
+    }
+
+    @Test
+    void createsUploadsDownloadsAndDeletesThroughBackendActorWebdavCalls() {
+        server.expect(requestTo("https://files.example.test/remote.php/dav/files/weave-service/Team/Design"))
+                .andExpect(method(HttpMethod.valueOf("MKCOL")))
+                .andExpect(header(HttpHeaders.AUTHORIZATION, AUTH_HEADER))
+                .andRespond(withStatus(HttpStatus.CREATED));
+        server.expect(requestTo("https://files.example.test/remote.php/dav/files/weave-service/Team/readme.md"))
+                .andExpect(method(HttpMethod.PUT))
+                .andExpect(header(HttpHeaders.AUTHORIZATION, AUTH_HEADER))
+                .andRespond(withStatus(HttpStatus.CREATED));
+        server.expect(requestTo("https://files.example.test/remote.php/dav/files/weave-service/Team/readme.md"))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header(HttpHeaders.AUTHORIZATION, AUTH_HEADER))
+                .andRespond(withSuccess("hello", MediaType.TEXT_PLAIN));
+        server.expect(requestTo("https://files.example.test/remote.php/dav/files/weave-service/Team/readme.md"))
+                .andExpect(method(HttpMethod.DELETE))
+                .andExpect(header(HttpHeaders.AUTHORIZATION, AUTH_HEADER))
+                .andRespond(withStatus(HttpStatus.NO_CONTENT));
+
+        assertThat(adapter.createFolder(new CreateFolderRequest("/Team", "Design")).path())
+                .isEqualTo("/Team/Design");
+        FileUploadResponse upload = adapter.upload("/Team", new MockMultipartFile(
+                "file", "readme.md", "text/markdown", "hello".getBytes(StandardCharsets.UTF_8)));
+        assertThat(upload.item().path()).isEqualTo("/Team/readme.md");
+        assertThat(upload.item().downloadable()).isTrue();
+
+        String fileId = FilePathCodec.toId("/Team/readme.md");
+        DownloadedFile download = adapter.download(fileId);
+        assertThat(download.filename()).isEqualTo("readme.md");
+        assertThat(download.mimeType()).isEqualTo("text/plain");
+        assertThat(download.content()).isEqualTo("hello".getBytes(StandardCharsets.UTF_8));
+
+        adapter.delete(fileId);
+        server.verify();
+    }
+
+    @Test
+    void mapsDownstreamNotFoundToStableProductError() {
+        server.expect(requestTo("https://files.example.test/remote.php/dav/files/weave-service/Missing"))
+                .andExpect(method(HttpMethod.valueOf("PROPFIND")))
+                .andRespond(withStatus(HttpStatus.NOT_FOUND));
+
+        assertThatThrownBy(() -> adapter.list("/Missing"))
+                .isInstanceOfSatisfying(ApiErrorException.class, exception -> {
+                    assertThat(exception.status()).isEqualTo(HttpStatus.NOT_FOUND);
+                    assertThat(exception.code()).isEqualTo("file-not-found");
+                    assertThat(exception.details()).containsEntry("operation", "list-files");
+                });
+        server.verify();
+    }
+
+    private NextcloudFilesProperties configuredProperties() {
+        return new NextcloudFilesProperties(
+                "https://files.example.test",
+                "/remote.php/dav/files",
+                "backend-service-account",
+                "weave-service",
+                "app-password");
+    }
+}


### PR DESCRIPTION
## Problem

The Files facade skeleton existed, but product file operations still failed with `nextcloud-adapter-not-configured`. MVP Files must go through `https://api.weave.local/api` with backend-owned Nextcloud integration, not direct Flutter-to-Nextcloud credentials.

Closes #24.
Closes #26.

## Target behavior

- Keep Files endpoints authenticated behind the existing `weave:workspace` boundary.
- Use a backend-owned Nextcloud WebDAV actor when explicitly configured.
- Fail closed when the backend actor model/credentials are missing instead of forwarding caller bearer tokens or exposing raw Nextcloud credentials to the app.

## Changes

- Adds `NextcloudFilesAdapter` for WebDAV list, create folder, upload, download, and delete.
- Adds file ID/path normalization and stable product error mapping for not found, conflict, permission, quota, auth/config, unavailable, and invalid downstream responses.
- Updates download endpoint to return file bytes with content type and content disposition.
- Adds `weave.nextcloud.files.*` configuration properties and README/env documentation for base URL, WebDAV root, actor model, actor username, and actor token.
- Adds controller, service, and adapter tests.

## Validation

Host Java is not installed, so validation used the documented Docker fallback:

```bash
docker run --rm -u "$(id -u):$(id -g)" -e HOME=/tmp -e GRADLE_USER_HOME=/tmp/.gradle -v "$PWD:/workspace" -w /workspace eclipse-temurin:17-jdk ./gradlew test
```

Result: PASS.

## Notes / remaining blockers

- No live Nextcloud integration was run in this PR.
- Current actor model is `backend-service-account`; delegated per-user token exchange/user mapping remains a future seam and fails closed if selected before implementation.
- Move/share are intentionally not implemented yet because product policy and endpoint contracts are not specified.
