### PR TITLE
fix(files): allow WebDAV methods in RestClient

### DIFF
--- a/src/main/java/com/massimotter/weave/backend/config/RestClientConfiguration.java
+++ b/src/main/java/com/massimotter/weave/backend/config/RestClientConfiguration.java
@@ -1,0 +1,18 @@
+package com.massimotter.weave.backend.config;
+
+import java.net.http.HttpClient;
+import org.springframework.boot.web.client.RestClientCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+
+@Configuration
+public class RestClientConfiguration {
+
+    @Bean
+    RestClientCustomizer jdkRestClientRequestFactoryCustomizer() {
+        HttpClient httpClient = HttpClient.newHttpClient();
+        JdkClientHttpRequestFactory requestFactory = new JdkClientHttpRequestFactory(httpClient);
+        return builder -> builder.requestFactory(requestFactory);
+    }
+}


### PR DESCRIPTION
## Summary
- Configure Spring `RestClient` to use the JDK HTTP client request factory.
- Unblocks WebDAV verbs such as `PROPFIND` and `MKCOL` for the Nextcloud files facade.

## Why
The files facade adapter uses `RestClient.method(PROPFIND)`. With the default request factory this fails before the downstream request is sent (`ResourceAccessException`), so `/api/files?path=/` returns HTTP 503 even though direct WebDAV access works.

## Validated
- `./gradlew --no-daemon test`
- Built a local backend image and verified live-stack `/api/files?path=/` returns HTTP 200 with a real Nextcloud directory listing after the change.

Unblocks masssi164/weave#89.
