### PR TITLE
feat(diagnostics): add actionable platform status

### DIFF
--- a/src/main/java/com/massimotter/weave/backend/config/ApiErrorResponseWriter.java
+++ b/src/main/java/com/massimotter/weave/backend/config/ApiErrorResponseWriter.java
@@ -7,7 +7,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -38,8 +37,8 @@ public class ApiErrorResponseWriter {
         response.setStatus(status.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
-        String requestId = requestId(request);
-        response.setHeader("X-Request-Id", requestId);
+        String requestId = RequestIdFilter.requestId(request);
+        response.setHeader(RequestIdFilter.HEADER, requestId);
         Map<String, Object> details = new LinkedHashMap<>();
         details.put("status", status.value());
         details.put("path", request.getRequestURI());
@@ -58,11 +57,4 @@ public class ApiErrorResponseWriter {
         return status.name().toLowerCase().replace('_', '-');
     }
 
-    private String requestId(HttpServletRequest request) {
-        String incoming = request.getHeader("X-Request-Id");
-        if (incoming != null && !incoming.isBlank()) {
-            return incoming.trim();
-        }
-        return UUID.randomUUID().toString();
-    }
 }

--- a/src/main/java/com/massimotter/weave/backend/config/RequestIdFilter.java
+++ b/src/main/java/com/massimotter/weave/backend/config/RequestIdFilter.java
@@ -1,0 +1,55 @@
+package com.massimotter.weave.backend.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class RequestIdFilter extends OncePerRequestFilter {
+
+    public static final String HEADER = "X-Request-Id";
+    public static final String ATTRIBUTE = RequestIdFilter.class.getName() + ".REQUEST_ID";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String requestId = requestId(request);
+        request.setAttribute(ATTRIBUTE, requestId);
+        response.setHeader(HEADER, requestId);
+
+        try (MDC.MDCCloseable ignored = MDC.putCloseable("requestId", requestId)) {
+            filterChain.doFilter(request, response);
+        }
+    }
+
+    public static String requestId(HttpServletRequest request) {
+        Object attribute = request.getAttribute(ATTRIBUTE);
+        if (attribute instanceof String value && !value.isBlank()) {
+            return value;
+        }
+
+        String incoming = request.getHeader(HEADER);
+        if (isSafeRequestId(incoming)) {
+            return incoming.trim();
+        }
+
+        return UUID.randomUUID().toString();
+    }
+
+    private static boolean isSafeRequestId(String value) {
+        return value != null
+                && !value.isBlank()
+                && value.length() <= 128
+                && value.chars().allMatch(character -> Character.isLetterOrDigit(character)
+                        || character == '-'
+                        || character == '_'
+                        || character == '.'
+                        || character == ':');
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/controller/HealthController.java
+++ b/src/main/java/com/massimotter/weave/backend/controller/HealthController.java
@@ -1,8 +1,12 @@
 package com.massimotter.weave.backend.controller;
 
+import com.massimotter.weave.backend.config.RequestIdFilter;
+import com.massimotter.weave.backend.model.PlatformStatusResponse;
+import com.massimotter.weave.backend.service.PlatformContractService;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
 import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
-import java.util.Map;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,24 +16,55 @@ import org.springframework.web.bind.annotation.RestController;
 public class HealthController {
 
     private final WorkspaceCapabilityService workspaceCapabilityService;
+    private final PlatformContractService platformContractService;
 
-    public HealthController(WorkspaceCapabilityService workspaceCapabilityService) {
+    public HealthController(
+            WorkspaceCapabilityService workspaceCapabilityService,
+            PlatformContractService platformContractService) {
         this.workspaceCapabilityService = workspaceCapabilityService;
+        this.platformContractService = platformContractService;
     }
 
     @GetMapping("/api/health/live")
-    public Map<String, String> live() {
-        return Map.of("status", "up");
+    public HealthResponse live(HttpServletRequest request) {
+        String requestId = RequestIdFilter.requestId(request);
+        return new HealthResponse(
+                "up",
+                requestId,
+                List.of(new PlatformStatusResponse.DiagnosticCheck(
+                        "backend",
+                        "Backend API",
+                        "up",
+                        "ready",
+                        "The Weave backend process is running.",
+                        null)),
+                List.of());
     }
 
     @GetMapping("/api/health/ready")
-    public ResponseEntity<Map<String, String>> ready() {
+    public ResponseEntity<HealthResponse> ready(HttpServletRequest request) {
+        PlatformStatusResponse status = platformContractService.status(RequestIdFilter.requestId(request));
         WorkspaceCapabilityReadiness readiness = workspaceCapabilityService.snapshot().shellAccess().readiness();
-        if (readiness == WorkspaceCapabilityReadiness.READY) {
-            return ResponseEntity.ok(Map.of("status", "up"));
+        if (readiness == WorkspaceCapabilityReadiness.READY && status.ready()) {
+            return ResponseEntity.ok(new HealthResponse(
+                    "up",
+                    status.requestId(),
+                    status.checks(),
+                    List.of()));
         }
         return ResponseEntity
                 .status(HttpStatus.SERVICE_UNAVAILABLE)
-                .body(Map.of("status", "blocked", "reason", "auth_contract_incomplete"));
+                .body(new HealthResponse(
+                        readiness == WorkspaceCapabilityReadiness.BLOCKED ? "blocked" : "degraded",
+                        status.requestId(),
+                        status.checks(),
+                        status.actions()));
+    }
+
+    public record HealthResponse(
+            String status,
+            String requestId,
+            List<PlatformStatusResponse.DiagnosticCheck> checks,
+            List<String> actions) {
     }
 }

--- a/src/main/java/com/massimotter/weave/backend/controller/PlatformController.java
+++ b/src/main/java/com/massimotter/weave/backend/controller/PlatformController.java
@@ -1,10 +1,12 @@
 package com.massimotter.weave.backend.controller;
 
+import com.massimotter.weave.backend.config.RequestIdFilter;
 import com.massimotter.weave.backend.model.PlatformConfigResponse;
 import com.massimotter.weave.backend.model.PlatformStatusResponse;
 import com.massimotter.weave.backend.service.PlatformContractService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,7 +28,7 @@ public class PlatformController {
 
     @GetMapping("/api/platform/status")
     @Operation(summary = "Get platform module status")
-    public PlatformStatusResponse status() {
-        return platformContractService.status();
+    public PlatformStatusResponse status(HttpServletRequest request) {
+        return platformContractService.status(RequestIdFilter.requestId(request));
     }
 }

--- a/src/main/java/com/massimotter/weave/backend/model/PlatformStatusResponse.java
+++ b/src/main/java/com/massimotter/weave/backend/model/PlatformStatusResponse.java
@@ -1,17 +1,57 @@
 package com.massimotter.weave.backend.model;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 
 @Schema(description = "Backend-owned status snapshot for admin diagnostics and smoke tests.")
 public record PlatformStatusResponse(
-        SimpleStatus backend,
-        SimpleStatus auth,
+        @Schema(description = "Correlation identifier also returned in the X-Request-Id response header.")
+        String requestId,
+        DiagnosticStatus backend,
+        DiagnosticStatus auth,
         MatrixStatus matrix,
-        SimpleStatus nextcloud) {
+        DiagnosticStatus files,
+        DiagnosticStatus calendar,
+        DiagnosticStatus nextcloud,
+        @Schema(description = "Normalized non-secret checks that admin UI, setup scripts, and smoke tests can render.")
+        List<DiagnosticCheck> checks,
+        @Schema(description = "Distinct operator actions for checks that are not ready.")
+        List<String> actions) {
 
-    public record SimpleStatus(String status) {
+    public boolean ready() {
+        return checks.stream()
+                .filter(check -> !"unavailable".equals(check.readiness()))
+                .allMatch(check -> "ready".equals(check.readiness()));
     }
 
-    public record MatrixStatus(String status, boolean federationEnabled, boolean e2eeEnabled) {
+    public record DiagnosticStatus(
+            @Schema(description = "Short machine-readable status: up, degraded, blocked, or disabled.")
+            String status,
+            @Schema(description = "Normalized readiness: ready, degraded, blocked, or unavailable.")
+            String readiness,
+            @Schema(description = "Plain-language, support-safe reason for the current state.")
+            String message,
+            @Schema(description = "Recommended non-secret operator action when not ready.")
+            String action) {
+    }
+
+    public record MatrixStatus(
+            String status,
+            String readiness,
+            String message,
+            String action,
+            boolean federationEnabled,
+            boolean e2eeEnabled) {
+    }
+
+    public record DiagnosticCheck(
+            @Schema(description = "Stable check identifier.", example = "auth")
+            String key,
+            @Schema(description = "Human-readable check label.", example = "Keycloak auth")
+            String label,
+            String status,
+            String readiness,
+            String message,
+            String action) {
     }
 }

--- a/src/main/java/com/massimotter/weave/backend/service/PlatformContractService.java
+++ b/src/main/java/com/massimotter/weave/backend/service/PlatformContractService.java
@@ -1,9 +1,13 @@
 package com.massimotter.weave.backend.service;
 
 import com.massimotter.weave.backend.config.PlatformContractProperties;
+import com.massimotter.weave.backend.config.WeaveSecurityProperties;
 import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
 import com.massimotter.weave.backend.model.PlatformConfigResponse;
 import com.massimotter.weave.backend.model.PlatformStatusResponse;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
 import org.springframework.stereotype.Service;
 
@@ -12,14 +16,17 @@ public class PlatformContractService {
 
     private final OAuth2ResourceServerProperties resourceServerProperties;
     private final PlatformContractProperties platformProperties;
+    private final WeaveSecurityProperties securityProperties;
     private final WorkspaceCapabilityProperties workspaceProperties;
 
     public PlatformContractService(
             OAuth2ResourceServerProperties resourceServerProperties,
             PlatformContractProperties platformProperties,
+            WeaveSecurityProperties securityProperties,
             WorkspaceCapabilityProperties workspaceProperties) {
         this.resourceServerProperties = resourceServerProperties;
         this.platformProperties = platformProperties;
+        this.securityProperties = securityProperties;
         this.workspaceProperties = workspaceProperties;
     }
 
@@ -44,24 +51,207 @@ public class PlatformContractService {
                         workspaceProperties.calendar().enabled()));
     }
 
-    public PlatformStatusResponse status() {
+    public PlatformStatusResponse status(String requestId) {
+        PlatformStatusResponse.DiagnosticStatus backend = new PlatformStatusResponse.DiagnosticStatus(
+                "up",
+                "ready",
+                "The Weave backend process is serving product API diagnostics.",
+                null);
+        PlatformStatusResponse.DiagnosticStatus auth = authStatus();
+        PlatformStatusResponse.MatrixStatus matrix = matrixStatus(auth);
+        PlatformStatusResponse.DiagnosticStatus files = moduleStatus(
+                "files",
+                "Files",
+                workspaceProperties.files(),
+                auth,
+                "Set WEAVE_NEXTCLOUD_BASE_URL to the canonical Nextcloud URL, for example https://files.weave.local.",
+                "Enable WEAVE_WORKSPACE_FILES_ENABLED when files should be available.");
+        PlatformStatusResponse.DiagnosticStatus calendar = moduleStatus(
+                "calendar",
+                "Calendar",
+                workspaceProperties.calendar(),
+                auth,
+                "Set WEAVE_CALDAV_BASE_URL or WEAVE_NEXTCLOUD_BASE_URL so calendar can reach Nextcloud CalDAV.",
+                "Enable WEAVE_WORKSPACE_CALENDAR_ENABLED when calendar should be available.");
+        PlatformStatusResponse.DiagnosticStatus nextcloud = nextcloudStatus();
+
+        List<PlatformStatusResponse.DiagnosticCheck> checks = List.of(
+                check("backend", "Backend API", backend),
+                check("auth", "Keycloak auth", auth),
+                check("matrix", "Matrix chat", matrix),
+                check("files", "Files module", files),
+                check("calendar", "Calendar module", calendar),
+                check("nextcloud", "Nextcloud route", nextcloud));
+
         return new PlatformStatusResponse(
-                new PlatformStatusResponse.SimpleStatus("up"),
-                new PlatformStatusResponse.SimpleStatus(hasText(resourceServerProperties.getJwt().getIssuerUri())
-                        ? "up"
-                        : "blocked"),
-                new PlatformStatusResponse.MatrixStatus(moduleStatus(workspaceProperties.chat()), false, false),
-                new PlatformStatusResponse.SimpleStatus(moduleStatus(workspaceProperties.files())));
+                requestId,
+                backend,
+                auth,
+                matrix,
+                files,
+                calendar,
+                nextcloud,
+                checks,
+                actions(checks));
     }
 
-    private String moduleStatus(WorkspaceCapabilityProperties.Capability capability) {
+    private PlatformStatusResponse.DiagnosticStatus authStatus() {
+        if (!workspaceProperties.shellAccess().enabled()) {
+            return new PlatformStatusResponse.DiagnosticStatus(
+                    "disabled",
+                    "unavailable",
+                    "Shell access is disabled for this backend runtime.",
+                    "Enable WEAVE_WORKSPACE_SHELL_ACCESS_ENABLED when authenticated Weave product APIs should serve traffic.");
+        }
+
+        List<String> missing = new ArrayList<>();
+        if (!hasText(resourceServerProperties.getJwt().getIssuerUri())) {
+            missing.add("WEAVE_OIDC_ISSUER_URI");
+        }
+        if (!hasText(securityProperties.requiredAudience())) {
+            missing.add("WEAVE_OIDC_REQUIRED_AUDIENCE");
+        }
+        if (!hasText(securityProperties.clientId())) {
+            missing.add("WEAVE_CLIENT_ID");
+        }
+
+        if (missing.isEmpty()) {
+            return new PlatformStatusResponse.DiagnosticStatus(
+                    "up",
+                    "ready",
+                    "JWT issuer, audience, client, and workspace-scope validation are configured.",
+                    null);
+        }
+
+        return new PlatformStatusResponse.DiagnosticStatus(
+                "blocked",
+                "blocked",
+                "Missing auth runtime inputs: " + String.join(", ", missing) + ".",
+                "Provide the missing auth runtime inputs for the backend: " + String.join(", ", missing) + ".");
+    }
+
+    private PlatformStatusResponse.MatrixStatus matrixStatus(PlatformStatusResponse.DiagnosticStatus auth) {
+        PlatformStatusResponse.DiagnosticStatus status = moduleStatus(
+                "matrix",
+                "Matrix chat",
+                workspaceProperties.chat(),
+                auth,
+                "Set WEAVE_MATRIX_HOMESERVER_URL to the public Matrix base URL, for example https://matrix.weave.local.",
+                "Enable WEAVE_WORKSPACE_CHAT_ENABLED when chat should be available.");
+        return new PlatformStatusResponse.MatrixStatus(
+                status.status(),
+                status.readiness(),
+                status.message(),
+                status.action(),
+                false,
+                false);
+    }
+
+    private PlatformStatusResponse.DiagnosticStatus moduleStatus(
+            String key,
+            String label,
+            WorkspaceCapabilityProperties.Capability capability,
+            PlatformStatusResponse.DiagnosticStatus auth,
+            String missingRouteAction,
+            String disabledAction) {
         if (!capability.enabled()) {
-            return "disabled";
+            return new PlatformStatusResponse.DiagnosticStatus(
+                    "disabled",
+                    "unavailable",
+                    label + " is disabled for this workspace snapshot.",
+                    disabledAction);
+        }
+        if ("blocked".equals(auth.readiness())) {
+            return new PlatformStatusResponse.DiagnosticStatus(
+                    "blocked",
+                    "blocked",
+                    label + " depends on shell access, which is currently blocked by the auth contract.",
+                    "Fix the first-party auth contract first, then re-check " + key + " readiness.");
         }
         if (capability.readiness() != null) {
-            return capability.readiness().name().toLowerCase();
+            return overriddenStatus(label, capability.readiness());
         }
-        return hasText(capability.dependencyUrl()) ? "up" : "degraded";
+        if (hasText(capability.dependencyUrl())) {
+            return new PlatformStatusResponse.DiagnosticStatus(
+                    "up",
+                    "ready",
+                    label + " has a configured public dependency route.",
+                    null);
+        }
+        return new PlatformStatusResponse.DiagnosticStatus(
+                "degraded",
+                "degraded",
+                label + " is enabled but no dependency route is configured.",
+                missingRouteAction);
+    }
+
+    private PlatformStatusResponse.DiagnosticStatus overriddenStatus(
+            String label,
+            WorkspaceCapabilityReadiness readiness) {
+        String normalized = readiness.name().toLowerCase();
+        String status = switch (readiness) {
+            case READY -> "up";
+            case DEGRADED -> "degraded";
+            case BLOCKED -> "blocked";
+            case UNAVAILABLE -> "disabled";
+        };
+        String action = readiness == WorkspaceCapabilityReadiness.READY
+                ? null
+                : "Review the configured " + label + " readiness override and downstream service wiring.";
+        return new PlatformStatusResponse.DiagnosticStatus(
+                status,
+                normalized,
+                label + " readiness is set by an explicit backend runtime override.",
+                action);
+    }
+
+    private PlatformStatusResponse.DiagnosticStatus nextcloudStatus() {
+        if (hasText(platformProperties.nextcloudBaseUrl())) {
+            return new PlatformStatusResponse.DiagnosticStatus(
+                    "up",
+                    "ready",
+                    "The canonical Nextcloud technical route is configured for backend files/calendar diagnostics.",
+                    null);
+        }
+        return new PlatformStatusResponse.DiagnosticStatus(
+                "degraded",
+                "degraded",
+                "The canonical Nextcloud technical route is not configured.",
+                "Set WEAVE_NEXTCLOUD_BASE_URL to the raw Nextcloud/admin/protocol origin, for example https://files.weave.local.");
+    }
+
+    private PlatformStatusResponse.DiagnosticCheck check(
+            String key,
+            String label,
+            PlatformStatusResponse.DiagnosticStatus status) {
+        return new PlatformStatusResponse.DiagnosticCheck(
+                key,
+                label,
+                status.status(),
+                status.readiness(),
+                status.message(),
+                status.action());
+    }
+
+    private PlatformStatusResponse.DiagnosticCheck check(
+            String key,
+            String label,
+            PlatformStatusResponse.MatrixStatus status) {
+        return new PlatformStatusResponse.DiagnosticCheck(
+                key,
+                label,
+                status.status(),
+                status.readiness(),
+                status.message(),
+                status.action());
+    }
+
+    private List<String> actions(List<PlatformStatusResponse.DiagnosticCheck> checks) {
+        return checks.stream()
+                .map(PlatformStatusResponse.DiagnosticCheck::action)
+                .filter(this::hasText)
+                .distinct()
+                .toList();
     }
 
     private boolean hasText(String value) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -77,6 +77,7 @@ weave:
       readiness: ${WEAVE_WORKSPACE_FILES_READINESS:}
     calendar:
       enabled: ${WEAVE_WORKSPACE_CALENDAR_ENABLED:false}
+      dependency-url: ${WEAVE_CALDAV_BASE_URL:${WEAVE_NEXTCLOUD_BASE_URL:https://files.weave.local}}
       readiness: ${WEAVE_WORKSPACE_CALENDAR_READINESS:}
     boards:
       enabled: ${WEAVE_WORKSPACE_BOARDS_ENABLED:false}

--- a/src/test/java/com/massimotter/weave/backend/config/MissingIssuerRuntimeContractTest.java
+++ b/src/test/java/com/massimotter/weave/backend/config/MissingIssuerRuntimeContractTest.java
@@ -8,6 +8,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -30,5 +31,32 @@ class MissingIssuerRuntimeContractTest {
                 .andExpect(jsonPath("$.details.status").value(401))
                 .andExpect(jsonPath("$.message").value(
                         "Bearer authentication is required and must satisfy the first-party Weave token contract."));
+    }
+
+    @Test
+    void exposesActionableDiagnosticsWhenAuthContractIsIncomplete() throws Exception {
+        mockMvc.perform(get("/api/platform/status")
+                        .header("X-Request-Id", "missing-auth-test"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("X-Request-Id", "missing-auth-test"))
+                .andExpect(jsonPath("$.requestId").value("missing-auth-test"))
+                .andExpect(jsonPath("$.auth.status").value("blocked"))
+                .andExpect(jsonPath("$.auth.readiness").value("blocked"))
+                .andExpect(jsonPath("$.auth.message").value("Missing auth runtime inputs: WEAVE_OIDC_ISSUER_URI."))
+                .andExpect(jsonPath("$.matrix.status").value("blocked"))
+                .andExpect(jsonPath("$.files.status").value("blocked"))
+                .andExpect(jsonPath("$.calendar.status").value("disabled"))
+                .andExpect(jsonPath("$.actions[0]").value(
+                        "Provide the missing auth runtime inputs for the backend: WEAVE_OIDC_ISSUER_URI."));
+
+        mockMvc.perform(get("/api/health/ready")
+                        .header("X-Request-Id", "missing-auth-ready-test"))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(header().string("X-Request-Id", "missing-auth-ready-test"))
+                .andExpect(jsonPath("$.status").value("blocked"))
+                .andExpect(jsonPath("$.requestId").value("missing-auth-ready-test"))
+                .andExpect(jsonPath("$.checks[?(@.key == 'auth')].readiness").value("blocked"))
+                .andExpect(jsonPath("$.actions[0]").value(
+                        "Provide the missing auth runtime inputs for the backend: WEAVE_OIDC_ISSUER_URI."));
     }
 }

--- a/src/test/java/com/massimotter/weave/backend/controller/PlatformControllerTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/PlatformControllerTest.java
@@ -22,6 +22,7 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -79,24 +80,44 @@ class PlatformControllerTest {
 
     @Test
     void exposesPublicPlatformStatus() throws Exception {
-        mockMvc.perform(get("/api/platform/status"))
+        mockMvc.perform(get("/api/platform/status")
+                        .header("X-Request-Id", "diag-test-1"))
                 .andExpect(status().isOk())
+                .andExpect(header().string("X-Request-Id", "diag-test-1"))
+                .andExpect(jsonPath("$.requestId").value("diag-test-1"))
                 .andExpect(jsonPath("$.backend.status").value("up"))
+                .andExpect(jsonPath("$.backend.readiness").value("ready"))
                 .andExpect(jsonPath("$.auth.status").value("up"))
+                .andExpect(jsonPath("$.auth.readiness").value("ready"))
                 .andExpect(jsonPath("$.matrix.status").value("up"))
+                .andExpect(jsonPath("$.matrix.readiness").value("ready"))
                 .andExpect(jsonPath("$.matrix.federationEnabled").value(false))
                 .andExpect(jsonPath("$.matrix.e2eeEnabled").value(false))
-                .andExpect(jsonPath("$.nextcloud.status").value("up"));
+                .andExpect(jsonPath("$.files.status").value("up"))
+                .andExpect(jsonPath("$.calendar.status").value("up"))
+                .andExpect(jsonPath("$.nextcloud.status").value("up"))
+                .andExpect(jsonPath("$.checks[?(@.key == 'auth')].readiness").value("ready"))
+                .andExpect(jsonPath("$.checks[?(@.key == 'calendar')].status").value("up"))
+                .andExpect(jsonPath("$.actions").isEmpty());
     }
 
     @Test
     void exposesPublicHealthEndpoints() throws Exception {
-        mockMvc.perform(get("/api/health/live"))
+        mockMvc.perform(get("/api/health/live")
+                        .header("X-Request-Id", "live-test-1"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value("up"));
+                .andExpect(header().string("X-Request-Id", "live-test-1"))
+                .andExpect(jsonPath("$.status").value("up"))
+                .andExpect(jsonPath("$.requestId").value("live-test-1"))
+                .andExpect(jsonPath("$.checks[0].key").value("backend"));
 
-        mockMvc.perform(get("/api/health/ready"))
+        mockMvc.perform(get("/api/health/ready")
+                        .header("X-Request-Id", "ready-test-1"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value("up"));
+                .andExpect(header().string("X-Request-Id", "ready-test-1"))
+                .andExpect(jsonPath("$.status").value("up"))
+                .andExpect(jsonPath("$.requestId").value("ready-test-1"))
+                .andExpect(jsonPath("$.checks[?(@.key == 'matrix')].readiness").value("ready"))
+                .andExpect(jsonPath("$.actions").isEmpty());
     }
 }


### PR DESCRIPTION
## Summary
- add request-id propagation for backend responses and structured API errors
- enrich `/api/platform/status` with normalized module diagnostics, checks, and admin actions
- return structured live/ready health payloads with actionable setup hints

## North Star
Moves Weave toward the admin-friendly startup solution: operators can see what is ready, blocked, or degraded without knowing Keycloak/Matrix/Nextcloud internals.

## Validation
- `./gradlew test --tests '*PlatformControllerTest' --tests '*MissingIssuerRuntimeContractTest'`
- Prior full worker validation: `./gradlew test`
