### PR TITLE
fix(api): expose canonical workspace readiness aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ This repository now starts as a JWT-protected Spring Boot API with:
 - `/api/health/live` and `/api/health/ready` endpoints for gateway and smoke checks
 - `/api/platform/config` and `/api/platform/status` endpoints for client bootstrap and diagnostics, including canonical `matrixHomeserverUrl` and `nextcloudBaseUrl` fields
 - a canonical `/api/me` endpoint for profile claim inspection and client/backend contract testing
-- a `/api/v1/workspace/capabilities` endpoint for the first backend-owned client contract
-- a `/api/v1/workspace/release-readiness` endpoint for operator-facing Release 1 setup status and remaining actions
+- `/api/workspace/capabilities` and compatibility `/api/v1/workspace/capabilities` endpoints for the first backend-owned client contract
+- `/api/workspace/release-readiness` and compatibility `/api/v1/workspace/release-readiness` endpoints for operator-facing Release 1 setup status and remaining actions
 - authenticated Files facade endpoints at `/api/files`, `/api/files/upload`, `/api/files/folders`, `/api/files/{id}/download`, and `/api/files/{id}` backed by Nextcloud WebDAV when configured
 - authenticated Calendar facade endpoints at `/api/calendar/events` and `/api/calendar/events/{id}`
 - OpenAPI JSON published at `/v3/api-docs`

--- a/docs/release-operations.md
+++ b/docs/release-operations.md
@@ -47,7 +47,7 @@ Protected endpoints return a stable JSON error envelope on auth failures and inc
   "message": "Bearer authentication is required and must satisfy the first-party Weave token contract.",
   "details": {
     "status": 401,
-    "path": "/api/v1/workspace/capabilities",
+    "path": "/api/workspace/capabilities",
     "error": "Unauthorized"
   },
   "requestId": "01HV..."
@@ -56,7 +56,9 @@ Protected endpoints return a stable JSON error envelope on auth failures and inc
 
 Use `401` for missing or invalid tokens. Use `403` when the token is authenticated but does not include `weave:workspace`.
 
-`/api/v1/workspace/release-readiness` is the backend-owned operator snapshot for Release 1. It rolls auth, Matrix chat, and Nextcloud files into one response and lists the exact remaining setup actions when the workspace is still degraded or blocked.
+`/api/workspace/release-readiness` is the backend-owned operator snapshot for Release 1. It rolls auth, Matrix chat, and Nextcloud files into one response and lists the exact remaining setup actions when the workspace is still degraded or blocked.
+
+The older `/api/v1/workspace/capabilities` and `/api/v1/workspace/release-readiness` paths remain compatibility aliases while clients migrate to the canonical non-versioned workspace routes.
 
 ## Minimum operator checks
 
@@ -65,8 +67,8 @@ Use `401` for missing or invalid tokens. Use `403` when the token is authenticat
 - `GET /api/platform/config` should return public product URLs, `matrixHomeserverUrl`, canonical `nextcloudBaseUrl`, and module flags
 - `GET /api/platform/status` should return module status for smoke and diagnostics
 - `GET /api/me` with a valid first-party token should return caller claims
-- `GET /api/v1/workspace/capabilities` with a valid first-party token should return the client-facing capability snapshot
-- `GET /api/v1/workspace/release-readiness` with a valid first-party token should return operator-facing Release 1 setup status and remaining actions
+- `GET /api/workspace/capabilities` with a valid first-party token should return the client-facing capability snapshot
+- `GET /api/workspace/release-readiness` with a valid first-party token should return operator-facing Release 1 setup status and remaining actions
 
 ## Logging and audit baseline
 

--- a/src/main/java/com/massimotter/weave/backend/controller/WorkspaceController.java
+++ b/src/main/java/com/massimotter/weave/backend/controller/WorkspaceController.java
@@ -13,11 +13,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/workspace")
 @Tag(name = "Workspace", description = "Workspace readiness and capability endpoints.")
 public class WorkspaceController {
 
@@ -31,7 +29,7 @@ public class WorkspaceController {
         this.workspaceReleaseReadinessService = workspaceReleaseReadinessService;
     }
 
-    @GetMapping("/capabilities")
+    @GetMapping({"/api/workspace/capabilities", "/api/v1/workspace/capabilities"})
     @Operation(
             summary = "Get workspace capability readiness",
             description = "Returns the backend-owned workspace capability snapshot consumed by the Weave client.",
@@ -50,7 +48,7 @@ public class WorkspaceController {
         return workspaceCapabilityService.snapshot();
     }
 
-    @GetMapping("/release-readiness")
+    @GetMapping({"/api/workspace/release-readiness", "/api/v1/workspace/release-readiness"})
     @Operation(
             summary = "Get Release 1 workspace readiness",
             description = "Returns an operator-facing snapshot of the backend-owned Release 1 dependencies and remaining setup actions.",

--- a/src/test/java/com/massimotter/weave/backend/config/FirstPartyIdentityContractTest.java
+++ b/src/test/java/com/massimotter/weave/backend/config/FirstPartyIdentityContractTest.java
@@ -38,6 +38,7 @@ class FirstPartyIdentityContractTest {
 
     private static final String REQUIRED_AUDIENCE = "weave-app";
     private static final String FIRST_PARTY_CLIENT_ID = "weave-app";
+    private static final String WORKSPACE_CAPABILITIES_PATH = "/api/workspace/capabilities";
 
     @Autowired
     private MockMvc mockMvc;
@@ -52,6 +53,13 @@ class FirstPartyIdentityContractTest {
 
     @Test
     void acceptsTokenWithFirstPartyContractAndWorkspaceScope() throws Exception {
+        mockMvc.perform(get(WORKSPACE_CAPABILITIES_PATH)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer valid-contract"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void keepsVersionedWorkspaceCapabilitiesPathAsCompatibilityAlias() throws Exception {
         mockMvc.perform(get("/api/v1/workspace/capabilities")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer valid-contract"))
                 .andExpect(status().isOk());
@@ -60,27 +68,27 @@ class FirstPartyIdentityContractTest {
     @ParameterizedTest
     @ValueSource(strings = {"wrong-audience", "missing-audience"})
     void rejectsTokensWithoutRequiredAudience(String tokenValue) throws Exception {
-        mockMvc.perform(get("/api/v1/workspace/capabilities")
+        mockMvc.perform(get(WORKSPACE_CAPABILITIES_PATH)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + tokenValue))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value("unauthorized"))
                 .andExpect(jsonPath("$.message").value(
                         "Bearer authentication is required and must satisfy the first-party Weave token contract."))
                 .andExpect(jsonPath("$.details.status").value(401))
-                .andExpect(jsonPath("$.details.path").value(endsWith("/api/v1/workspace/capabilities")))
+                .andExpect(jsonPath("$.details.path").value(endsWith(WORKSPACE_CAPABILITIES_PATH)))
                 .andExpect(jsonPath("$.requestId").value(notNullValue()));
     }
 
     @Test
     void rejectsTokenWithoutWorkspaceScope() throws Exception {
-        mockMvc.perform(get("/api/v1/workspace/capabilities")
+        mockMvc.perform(get(WORKSPACE_CAPABILITIES_PATH)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer missing-scope"))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.code").value("forbidden"))
                 .andExpect(jsonPath("$.message").value(
                         "The bearer token is authenticated but missing the required weave:workspace scope."))
                 .andExpect(jsonPath("$.details.status").value(403))
-                .andExpect(jsonPath("$.details.path").value(endsWith("/api/v1/workspace/capabilities")))
+                .andExpect(jsonPath("$.details.path").value(endsWith(WORKSPACE_CAPABILITIES_PATH)))
                 .andExpect(jsonPath("$.requestId").value(notNullValue()));
     }
 
@@ -92,14 +100,14 @@ class FirstPartyIdentityContractTest {
             "conflicting-authorized-party"
     })
     void rejectsTokensWithoutRequiredAuthorizedParty(String tokenValue) throws Exception {
-        mockMvc.perform(get("/api/v1/workspace/capabilities")
+        mockMvc.perform(get(WORKSPACE_CAPABILITIES_PATH)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + tokenValue))
                 .andExpect(status().isUnauthorized());
     }
 
     @Test
     void acceptsClientIdClaimWhenAzpIsAbsent() throws Exception {
-        mockMvc.perform(get("/api/v1/workspace/capabilities")
+        mockMvc.perform(get(WORKSPACE_CAPABILITIES_PATH)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer client-id-only"))
                 .andExpect(status().isOk());
     }

--- a/src/test/java/com/massimotter/weave/backend/controller/OpenApiDocumentationTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/OpenApiDocumentationTest.java
@@ -43,6 +43,8 @@ class OpenApiDocumentationTest {
                 .andExpect(jsonPath("$.paths['/api/files/{id}']").exists())
                 .andExpect(jsonPath("$.paths['/api/calendar/events']").exists())
                 .andExpect(jsonPath("$.paths['/api/calendar/events/{id}']").exists())
+                .andExpect(jsonPath("$.paths['/api/workspace/capabilities']").exists())
+                .andExpect(jsonPath("$.paths['/api/workspace/release-readiness']").exists())
                 .andExpect(jsonPath("$.paths['/api/v1/workspace/capabilities']").exists())
                 .andExpect(jsonPath("$.paths['/api/v1/workspace/release-readiness']").exists())
                 .andExpect(jsonPath("$.components.schemas.ApiErrorResponse.properties.code.type").value("string"))

--- a/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
@@ -70,7 +70,13 @@ class WorkspaceControllerTest {
 
     @Test
     void rejectsAnonymousRequests() throws Exception {
+        mockMvc.perform(get("/api/workspace/capabilities"))
+                .andExpect(status().isUnauthorized());
+
         mockMvc.perform(get("/api/v1/workspace/capabilities"))
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(get("/api/workspace/release-readiness"))
                 .andExpect(status().isUnauthorized());
 
         mockMvc.perform(get("/api/v1/workspace/release-readiness"))

--- a/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
@@ -58,7 +58,27 @@ class WorkspaceControllerTest {
 
     @Test
     void returnsConfiguredWorkspaceCapabilities() throws Exception {
-        mockMvc.perform(get("/api/v1/workspace/capabilities").with(jwt()
+        assertConfiguredWorkspaceCapabilities("/api/workspace/capabilities");
+        assertConfiguredWorkspaceCapabilities("/api/v1/workspace/capabilities");
+    }
+
+    @Test
+    void returnsReleaseReadinessSnapshot() throws Exception {
+        assertReleaseReadinessSnapshot("/api/workspace/release-readiness");
+        assertReleaseReadinessSnapshot("/api/v1/workspace/release-readiness");
+    }
+
+    @Test
+    void rejectsAnonymousRequests() throws Exception {
+        mockMvc.perform(get("/api/v1/workspace/capabilities"))
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(get("/api/v1/workspace/release-readiness"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    private void assertConfiguredWorkspaceCapabilities(String path) throws Exception {
+        mockMvc.perform(get(path).with(jwt()
                         .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.shellAccess.enabled").value(true))
@@ -70,9 +90,8 @@ class WorkspaceControllerTest {
                 .andExpect(jsonPath("$.boards.readiness").value("unavailable"));
     }
 
-    @Test
-    void returnsReleaseReadinessSnapshot() throws Exception {
-        mockMvc.perform(get("/api/v1/workspace/release-readiness").with(jwt()
+    private void assertReleaseReadinessSnapshot(String path) throws Exception {
+        mockMvc.perform(get(path).with(jwt()
                         .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.readiness").value("ready"))
@@ -80,14 +99,5 @@ class WorkspaceControllerTest {
                 .andExpect(jsonPath("$.checks[1].key").value("chat"))
                 .andExpect(jsonPath("$.checks[2].key").value("files"))
                 .andExpect(jsonPath("$.actions").isEmpty());
-    }
-
-    @Test
-    void rejectsAnonymousRequests() throws Exception {
-        mockMvc.perform(get("/api/v1/workspace/capabilities"))
-                .andExpect(status().isUnauthorized());
-
-        mockMvc.perform(get("/api/v1/workspace/release-readiness"))
-                .andExpect(status().isUnauthorized());
     }
 }


### PR DESCRIPTION
## Summary
- add canonical `/api/workspace/capabilities` and `/api/workspace/release-readiness` routes
- keep existing `/api/v1/workspace/...` routes as compatibility aliases
- update OpenAPI/controller coverage and README baseline docs

## Why
Frontend live-stack contract work now targets backend facade paths under the canonical `/api` surface. This preserves the existing v1 routes while unblocking clients/tests that call `/api/workspace/capabilities` through the configured `https://api.weave.local/api` base.

## Spec/contract impact
- Local spec `specs/06-api-routing-and-backend-contract.md` was updated in the workspace to list the canonical workspace endpoints and document `/api/v1/workspace/...` as compatibility aliases.
- No auth, role, token, or infra routing behavior changes.

## Validation
- `./gradlew test --tests 'com.massimotter.weave.backend.controller.WorkspaceControllerTest' --tests 'com.massimotter.weave.backend.controller.OpenApiDocumentationTest'`
- `./gradlew test`
- `./gradlew check`

## Follow-up
- Re-run weave PR #92/#91 live-stack checks against this backend branch or after merge to confirm the frontend/backend route contract is green.

Refs masssi164/weave#92
Refs masssi164/weave#91
Refs #32
