### PR TITLE
feat: expose first-run onboarding status

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This repository now starts as a JWT-protected Spring Boot API with:
 - `/api/health/live` and `/api/health/ready` endpoints for gateway and smoke checks
 - `/api/platform/config` and `/api/platform/status` endpoints for client bootstrap and diagnostics, including canonical `matrixHomeserverUrl` and `nextcloudBaseUrl` fields
 - a canonical `/api/me` endpoint for profile claim inspection and client/backend contract testing
+- `/api/onboarding/status` for authenticated first-run invite, role/group, profile, Matrix, and Nextcloud provisioning status
 - `/api/workspace/capabilities` and compatibility `/api/v1/workspace/capabilities` endpoints for the first backend-owned client contract
 - `/api/workspace/release-readiness` and compatibility `/api/v1/workspace/release-readiness` endpoints for operator-facing Release 1 setup status and remaining actions
 - authenticated Files facade endpoints at `/api/files`, `/api/files/upload`, `/api/files/folders`, `/api/files/{id}/download`, and `/api/files/{id}` backed by Nextcloud WebDAV when configured
@@ -63,6 +64,8 @@ Optional runtime variables:
 - `WEAVE_CALDAV_REQUEST_TIMEOUT_SECONDS`: CalDAV request timeout, defaults to `10`
 - `WEAVE_WORKSPACE_BOARDS_ENABLED`: enable the boards capability, defaults to `false`
 - `WEAVE_WORKSPACE_BOARDS_READINESS`: optional explicit boards readiness override (`ready`, `degraded`, `blocked`, `unavailable`)
+- `WEAVE_ONBOARDING_MATRIX_PROVISIONING_STATE`: optional first-run Matrix provisioning override (`not_configured`, `pending`, `ready`, `degraded`, `failed`); blank derives status from the chat capability
+- `WEAVE_ONBOARDING_NEXTCLOUD_PROVISIONING_STATE`: optional first-run Nextcloud provisioning override (`not_configured`, `pending`, `ready`, `degraded`, `failed`); blank derives status from files/calendar capability and Nextcloud route configuration
 - `WEAVE_PUBLIC_BASE_URL`: public product entrypoint, defaults to `https://weave.local`
 - `WEAVE_API_BASE_URL`: public backend API base URL, defaults to `https://api.weave.local/api`
 - `WEAVE_AUTH_BASE_URL`: public Keycloak base URL, defaults to `https://auth.weave.local`
@@ -84,6 +87,14 @@ Files adapter behavior:
 - Implemented WebDAV operations: folder listing with quota when returned by Nextcloud, folder creation, upload, download, and delete.
 - Move/share remain intentionally unsupported until product policy and endpoint contracts are specified.
 - No live Nextcloud integration is implied by unit tests; local/live validation still requires a configured `files.weave.local` and backend actor.
+
+First-run onboarding status:
+
+- `GET /api/onboarding/status` is protected by the same first-party bearer-token contract as `/api/me`.
+- The response includes identity, roles, groups, invite status, profile completeness, and module provisioning states for `identity`, `profile`, `matrix`, and `nextcloud`.
+- Invite status is derived from trusted token claims (`weave_invite_status` or `invite_status` when present), falling back to email verification state for local/dev seed users.
+- Matrix and Nextcloud provisioning states are frontend-safe `not_configured`, `pending`, `ready`, `degraded`, or `failed` values. They do not include downstream stack traces, tokens, or raw service errors.
+- Owner and admin map to workspace administration/invite authority; member can use workspace modules; guest is treated as restricted for first-run module access.
 
 Workspace capability source of truth:
 

--- a/docs/release-operations.md
+++ b/docs/release-operations.md
@@ -20,6 +20,8 @@ Optional:
 - `WEAVE_FILES_PRODUCT_URL`: public files product surface, defaults to `https://weave.local/files`
 - `WEAVE_CALENDAR_PRODUCT_URL`: public calendar product surface, defaults to `https://weave.local/calendar`
 - `WEAVE_NEXTCLOUD_BASE_URL`: canonical Nextcloud URL, defaults to `https://files.weave.local`
+- `WEAVE_ONBOARDING_MATRIX_PROVISIONING_STATE`: optional first-run Matrix provisioning override (`not_configured`, `pending`, `ready`, `degraded`, `failed`); blank derives status from the chat capability
+- `WEAVE_ONBOARDING_NEXTCLOUD_PROVISIONING_STATE`: optional first-run Nextcloud provisioning override (`not_configured`, `pending`, `ready`, `degraded`, `failed`); blank derives status from files/calendar capability and Nextcloud route configuration
 - `PORT`: HTTP listen port, defaults to `8080`
 
 ## Local/dev public contract
@@ -56,6 +58,8 @@ Protected endpoints return a stable JSON error envelope on auth failures and inc
 
 Use `401` for missing or invalid tokens. Use `403` when the token is authenticated but does not include `weave:workspace`.
 
+`/api/onboarding/status` is the authenticated first-run user snapshot. It returns identity, role/group routing data, invite status, profile completeness, and frontend-safe provisioning states for identity, profile, Matrix, and Nextcloud. Matrix/Nextcloud states are `not_configured`, `pending`, `ready`, `degraded`, or `failed`; response messages must remain support-safe and must not expose downstream stack traces, secrets, tokens, or raw infrastructure errors.
+
 `/api/workspace/release-readiness` is the backend-owned operator snapshot for Release 1. It rolls auth, Matrix chat, and Nextcloud files into one response and lists the exact remaining setup actions when the workspace is still degraded or blocked.
 
 The older `/api/v1/workspace/capabilities` and `/api/v1/workspace/release-readiness` paths remain compatibility aliases while clients migrate to the canonical non-versioned workspace routes.
@@ -67,6 +71,7 @@ The older `/api/v1/workspace/capabilities` and `/api/v1/workspace/release-readin
 - `GET /api/platform/config` should return public product URLs, `matrixHomeserverUrl`, canonical `nextcloudBaseUrl`, and module flags
 - `GET /api/platform/status` should return module status for smoke and diagnostics
 - `GET /api/me` with a valid first-party token should return caller claims
+- `GET /api/onboarding/status` with a valid first-party token should return first-run invite, role/group, profile, Matrix, and Nextcloud provisioning status
 - `GET /api/workspace/capabilities` with a valid first-party token should return the client-facing capability snapshot
 - `GET /api/workspace/release-readiness` with a valid first-party token should return operator-facing Release 1 setup status and remaining actions
 

--- a/src/main/java/com/massimotter/weave/backend/WeaveBackendApplication.java
+++ b/src/main/java/com/massimotter/weave/backend/WeaveBackendApplication.java
@@ -2,6 +2,7 @@ package com.massimotter.weave.backend;
 
 import com.massimotter.weave.backend.config.CalendarCalDavProperties;
 import com.massimotter.weave.backend.config.NextcloudFilesProperties;
+import com.massimotter.weave.backend.config.OnboardingStatusProperties;
 import com.massimotter.weave.backend.config.PlatformContractProperties;
 import com.massimotter.weave.backend.config.WeaveSecurityProperties;
 import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
@@ -13,6 +14,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 @EnableConfigurationProperties({
         CalendarCalDavProperties.class,
         NextcloudFilesProperties.class,
+        OnboardingStatusProperties.class,
         PlatformContractProperties.class,
         WeaveSecurityProperties.class,
         WorkspaceCapabilityProperties.class

--- a/src/main/java/com/massimotter/weave/backend/config/OnboardingStatusProperties.java
+++ b/src/main/java/com/massimotter/weave/backend/config/OnboardingStatusProperties.java
@@ -1,0 +1,22 @@
+package com.massimotter.weave.backend.config;
+
+import com.massimotter.weave.backend.model.OnboardingProvisioningState;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "weave.onboarding")
+public record OnboardingStatusProperties(
+        ModuleProvisioning matrix,
+        ModuleProvisioning nextcloud) {
+
+    public OnboardingStatusProperties {
+        matrix = module(matrix);
+        nextcloud = module(nextcloud);
+    }
+
+    private static ModuleProvisioning module(ModuleProvisioning module) {
+        return module == null ? new ModuleProvisioning(null) : module;
+    }
+
+    public record ModuleProvisioning(OnboardingProvisioningState provisioningState) {
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/controller/OnboardingController.java
+++ b/src/main/java/com/massimotter/weave/backend/controller/OnboardingController.java
@@ -1,0 +1,46 @@
+package com.massimotter.weave.backend.controller;
+
+import com.massimotter.weave.backend.model.ApiErrorResponse;
+import com.massimotter.weave.backend.model.OnboardingStatusResponse;
+import com.massimotter.weave.backend.service.OnboardingStatusService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Tag(name = "Onboarding", description = "First-run user invite and module provisioning status.")
+public class OnboardingController {
+
+    private final OnboardingStatusService onboardingStatusService;
+
+    public OnboardingController(OnboardingStatusService onboardingStatusService) {
+        this.onboardingStatusService = onboardingStatusService;
+    }
+
+    @GetMapping("/api/onboarding/status")
+    @Operation(
+            summary = "Get first-run invite and module provisioning status",
+            description = "Returns the authenticated caller identity, role mapping, profile readiness, and Matrix/Nextcloud provisioning states for first-run routing.",
+            security = @SecurityRequirement(name = "bearer-jwt"))
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "First-run onboarding status for the authenticated caller.",
+                    content = @Content(schema = @Schema(implementation = OnboardingStatusResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Missing or invalid bearer token.",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Bearer token is missing the weave:workspace scope.",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+    })
+    public OnboardingStatusResponse status(@AuthenticationPrincipal Jwt jwt) {
+        return onboardingStatusService.status(jwt);
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/model/OnboardingProvisioningState.java
+++ b/src/main/java/com/massimotter/weave/backend/model/OnboardingProvisioningState.java
@@ -1,0 +1,24 @@
+package com.massimotter.weave.backend.model;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Provisioning states exposed to first-run users for downstream modules.")
+public enum OnboardingProvisioningState {
+    NOT_CONFIGURED("not_configured"),
+    PENDING("pending"),
+    READY("ready"),
+    DEGRADED("degraded"),
+    FAILED("failed");
+
+    private final String value;
+
+    OnboardingProvisioningState(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String value() {
+        return value;
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/model/OnboardingStatusResponse.java
+++ b/src/main/java/com/massimotter/weave/backend/model/OnboardingStatusResponse.java
@@ -1,0 +1,72 @@
+package com.massimotter.weave.backend.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "First-run status for authenticated Weave users and admin onboarding flows.")
+public record OnboardingStatusResponse(
+        @Schema(description = "Canonical identity and profile data needed for first-run routing.")
+        Identity identity,
+        @Schema(description = "Invite or activation status derived from trusted identity claims.")
+        InviteStatus invite,
+        @Schema(description = "Product role mapping for first-run access decisions.")
+        Access access,
+        @Schema(description = "Profile completeness needed before landing in the full workspace.")
+        ProfileStatus profile,
+        @Schema(description = "Provisioning status for downstream collaboration modules.")
+        ModuleProvisioning moduleProvisioning,
+        @Schema(description = "True when invite, profile, and required modules are ready.")
+        boolean firstRunComplete,
+        @Schema(description = "Frontend-safe next steps for statuses that are not ready.")
+        List<String> actions) {
+
+    public record Identity(
+            String userId,
+            String username,
+            String email,
+            boolean emailVerified,
+            String displayName,
+            String locale,
+            String timezone,
+            List<String> roles,
+            List<String> groups) {
+    }
+
+    public record InviteStatus(
+            @Schema(description = "active, pending, or disabled.", example = "active")
+            String status,
+            String message,
+            String action) {
+    }
+
+    public record Access(
+            @Schema(description = "Highest MVP product role for routing: owner, admin, member, guest, or unassigned.")
+            String primaryRole,
+            List<String> roles,
+            List<String> groups,
+            boolean canAdministerWorkspace,
+            boolean canInviteUsers,
+            boolean canUseWorkspaceModules) {
+    }
+
+    public record ProfileStatus(
+            @Schema(description = "ready or pending.", example = "ready")
+            String status,
+            List<String> missing,
+            String message,
+            String action) {
+    }
+
+    public record ModuleProvisioning(
+            ModuleStatus identity,
+            ModuleStatus profile,
+            ModuleStatus matrix,
+            ModuleStatus nextcloud) {
+    }
+
+    public record ModuleStatus(
+            OnboardingProvisioningState state,
+            String message,
+            String action) {
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/service/OnboardingStatusService.java
+++ b/src/main/java/com/massimotter/weave/backend/service/OnboardingStatusService.java
@@ -1,0 +1,357 @@
+package com.massimotter.weave.backend.service;
+
+import com.massimotter.weave.backend.config.OnboardingStatusProperties;
+import com.massimotter.weave.backend.config.PlatformContractProperties;
+import com.massimotter.weave.backend.config.WeaveSecurityProperties;
+import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
+import com.massimotter.weave.backend.model.OnboardingProvisioningState;
+import com.massimotter.weave.backend.model.OnboardingStatusResponse;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OnboardingStatusService {
+
+    private static final List<String> ROLE_PRIORITY = List.of("owner", "admin", "member", "guest");
+    private static final Set<String> INVITE_STATUSES = Set.of("active", "pending", "disabled");
+
+    private final OAuth2ResourceServerProperties resourceServerProperties;
+    private final WeaveSecurityProperties securityProperties;
+    private final WorkspaceCapabilityProperties workspaceProperties;
+    private final PlatformContractProperties platformProperties;
+    private final OnboardingStatusProperties onboardingProperties;
+
+    public OnboardingStatusService(
+            OAuth2ResourceServerProperties resourceServerProperties,
+            WeaveSecurityProperties securityProperties,
+            WorkspaceCapabilityProperties workspaceProperties,
+            PlatformContractProperties platformProperties,
+            OnboardingStatusProperties onboardingProperties) {
+        this.resourceServerProperties = resourceServerProperties;
+        this.securityProperties = securityProperties;
+        this.workspaceProperties = workspaceProperties;
+        this.platformProperties = platformProperties;
+        this.onboardingProperties = onboardingProperties;
+    }
+
+    public OnboardingStatusResponse status(Jwt jwt) {
+        String subject = jwt.getSubject();
+        String username = firstText(jwt.getClaimAsString("preferred_username"), subject);
+        String email = jwt.getClaimAsString("email");
+        boolean emailVerified = emailVerified(jwt);
+        String displayName = firstText(jwt.getClaimAsString("name"), username);
+        String locale = firstText(jwt.getClaimAsString("locale"), "en");
+        String timezone = firstText(jwt.getClaimAsString("timezone"), "UTC");
+        List<String> roles = productRoles(extractRealmRoles(jwt));
+        List<String> groups = extractStringList(jwt, "groups");
+
+        OnboardingStatusResponse.Identity identity = new OnboardingStatusResponse.Identity(
+                subject,
+                username,
+                email,
+                emailVerified,
+                displayName,
+                locale,
+                timezone,
+                roles,
+                groups);
+        OnboardingStatusResponse.InviteStatus invite = inviteStatus(jwt, email, emailVerified);
+        OnboardingStatusResponse.Access access = access(roles, groups);
+        OnboardingStatusResponse.ProfileStatus profile = profileStatus(username, email, emailVerified, displayName, locale, timezone);
+        OnboardingStatusResponse.ModuleProvisioning moduleProvisioning = moduleProvisioning(profile);
+
+        List<String> actions = actions(invite, profile, moduleProvisioning);
+        boolean firstRunComplete = "active".equals(invite.status())
+                && "ready".equals(profile.status())
+                && moduleProvisioning.identity().state() == OnboardingProvisioningState.READY
+                && moduleProvisioning.profile().state() == OnboardingProvisioningState.READY
+                && moduleProvisioning.matrix().state() == OnboardingProvisioningState.READY
+                && moduleProvisioning.nextcloud().state() == OnboardingProvisioningState.READY;
+
+        return new OnboardingStatusResponse(
+                identity,
+                invite,
+                access,
+                profile,
+                moduleProvisioning,
+                firstRunComplete,
+                actions);
+    }
+
+    private OnboardingStatusResponse.InviteStatus inviteStatus(Jwt jwt, String email, boolean emailVerified) {
+        String claimedStatus = normalizeInviteStatus(firstText(
+                jwt.getClaimAsString("weave_invite_status"),
+                jwt.getClaimAsString("invite_status")));
+        if (claimedStatus != null) {
+            return switch (claimedStatus) {
+                case "pending" -> new OnboardingStatusResponse.InviteStatus(
+                        "pending",
+                        "The invite exists but still needs acceptance or activation before the full workspace is available.",
+                        "Ask a workspace owner or admin to finish activating this account if the invite was already accepted.");
+                case "disabled" -> new OnboardingStatusResponse.InviteStatus(
+                        "disabled",
+                        "This account is disabled for the Weave workspace.",
+                        "Ask a workspace owner or admin to reactivate the account.");
+                default -> new OnboardingStatusResponse.InviteStatus(
+                        "active",
+                        "The invite has been accepted and the account is active for Weave.",
+                        null);
+            };
+        }
+        if (!hasText(email) || !emailVerified) {
+            return new OnboardingStatusResponse.InviteStatus(
+                    "pending",
+                    "The account can authenticate, but email verification is not complete yet.",
+                    "Verify the email address in the identity provider, then sign in again.");
+        }
+        return new OnboardingStatusResponse.InviteStatus(
+                "active",
+                "The invite has been accepted and the account is active for Weave.",
+                null);
+    }
+
+    private String normalizeInviteStatus(String value) {
+        if (!hasText(value)) {
+            return null;
+        }
+        String normalized = value.trim().toLowerCase(Locale.ROOT).replace('-', '_');
+        return INVITE_STATUSES.contains(normalized) ? normalized : null;
+    }
+
+    private OnboardingStatusResponse.Access access(List<String> roles, List<String> groups) {
+        String primaryRole = ROLE_PRIORITY.stream()
+                .filter(roles::contains)
+                .findFirst()
+                .orElse("unassigned");
+        return new OnboardingStatusResponse.Access(
+                primaryRole,
+                roles,
+                groups,
+                "owner".equals(primaryRole) || "admin".equals(primaryRole),
+                "owner".equals(primaryRole) || "admin".equals(primaryRole),
+                List.of("owner", "admin", "member").contains(primaryRole));
+    }
+
+    private OnboardingStatusResponse.ProfileStatus profileStatus(
+            String username,
+            String email,
+            boolean emailVerified,
+            String displayName,
+            String locale,
+            String timezone) {
+        List<String> missing = new ArrayList<>();
+        if (!hasText(username)) {
+            missing.add("username");
+        }
+        if (!hasText(email)) {
+            missing.add("email");
+        }
+        if (hasText(email) && !emailVerified) {
+            missing.add("email_verified");
+        }
+        if (!hasText(displayName)) {
+            missing.add("display_name");
+        }
+        if (!hasText(locale)) {
+            missing.add("locale");
+        }
+        if (!hasText(timezone)) {
+            missing.add("timezone");
+        }
+
+        if (missing.isEmpty()) {
+            return new OnboardingStatusResponse.ProfileStatus(
+                    "ready",
+                    List.of(),
+                    "The Weave profile has the required first-run identity fields.",
+                    null);
+        }
+        return new OnboardingStatusResponse.ProfileStatus(
+                "pending",
+                List.copyOf(missing),
+                "The Weave profile is missing required first-run fields.",
+                "Complete the missing profile fields before using the full workspace.");
+    }
+
+    private OnboardingStatusResponse.ModuleProvisioning moduleProvisioning(
+            OnboardingStatusResponse.ProfileStatus profile) {
+        OnboardingStatusResponse.ModuleStatus identity = new OnboardingStatusResponse.ModuleStatus(
+                OnboardingProvisioningState.READY,
+                "Identity is available from the authenticated Keycloak-backed session.",
+                null);
+        OnboardingProvisioningState profileState = "ready".equals(profile.status())
+                ? OnboardingProvisioningState.READY
+                : OnboardingProvisioningState.PENDING;
+        OnboardingStatusResponse.ModuleStatus profileModule = new OnboardingStatusResponse.ModuleStatus(
+                profileState,
+                profileState == OnboardingProvisioningState.READY
+                        ? "The product profile is ready for module synchronization."
+                        : "The product profile is waiting for required fields before module synchronization.",
+                profile.action());
+        OnboardingStatusResponse.ModuleStatus matrix = moduleStatus(
+                "Matrix chat",
+                onboardingProperties.matrix().provisioningState(),
+                workspaceProperties.chat(),
+                workspaceProperties.chat().dependencyUrl(),
+                "Enable WEAVE_WORKSPACE_CHAT_ENABLED and configure WEAVE_MATRIX_HOMESERVER_URL before first-run chat provisioning.");
+        WorkspaceCapabilityProperties.Capability nextcloudCapability = workspaceProperties.files().enabled()
+                ? workspaceProperties.files()
+                : workspaceProperties.calendar();
+        String nextcloudDependencyUrl = firstText(nextcloudCapability.dependencyUrl(), platformProperties.nextcloudBaseUrl());
+        OnboardingStatusResponse.ModuleStatus nextcloud = moduleStatus(
+                "Nextcloud files/calendar",
+                onboardingProperties.nextcloud().provisioningState(),
+                nextcloudCapability,
+                nextcloudDependencyUrl,
+                "Enable files or calendar and configure WEAVE_NEXTCLOUD_BASE_URL before first-run Nextcloud provisioning.");
+        return new OnboardingStatusResponse.ModuleProvisioning(identity, profileModule, matrix, nextcloud);
+    }
+
+    private OnboardingStatusResponse.ModuleStatus moduleStatus(
+            String label,
+            OnboardingProvisioningState explicitState,
+            WorkspaceCapabilityProperties.Capability capability,
+            String dependencyUrl,
+            String notConfiguredAction) {
+        OnboardingProvisioningState state = explicitState != null
+                ? explicitState
+                : derivedProvisioningState(capability, dependencyUrl);
+        String message = switch (state) {
+            case NOT_CONFIGURED -> label + " provisioning is not configured for this workspace runtime.";
+            case PENDING -> label + " provisioning is pending and may still be completing.";
+            case READY -> label + " provisioning is ready for this user.";
+            case DEGRADED -> label + " provisioning is available but degraded.";
+            case FAILED -> label + " provisioning failed or is blocked by the backend runtime contract.";
+        };
+        String action = switch (state) {
+            case NOT_CONFIGURED -> notConfiguredAction;
+            case PENDING -> "Wait briefly, then retry. If this persists, ask a workspace admin to check module provisioning.";
+            case READY -> null;
+            case DEGRADED -> "Check the configured module route and downstream service health.";
+            case FAILED -> "Ask a workspace admin to inspect backend auth and module provisioning diagnostics.";
+        };
+        return new OnboardingStatusResponse.ModuleStatus(state, message, action);
+    }
+
+    private OnboardingProvisioningState derivedProvisioningState(
+            WorkspaceCapabilityProperties.Capability capability,
+            String dependencyUrl) {
+        if (capability == null || !capability.enabled()) {
+            return OnboardingProvisioningState.NOT_CONFIGURED;
+        }
+        if (shellAccessReadiness() == WorkspaceCapabilityReadiness.BLOCKED) {
+            return OnboardingProvisioningState.FAILED;
+        }
+        if (capability.readiness() != null) {
+            return switch (capability.readiness()) {
+                case READY -> OnboardingProvisioningState.READY;
+                case DEGRADED -> OnboardingProvisioningState.DEGRADED;
+                case BLOCKED -> OnboardingProvisioningState.FAILED;
+                case UNAVAILABLE -> OnboardingProvisioningState.NOT_CONFIGURED;
+            };
+        }
+        if (hasText(dependencyUrl)) {
+            return OnboardingProvisioningState.READY;
+        }
+        return OnboardingProvisioningState.DEGRADED;
+    }
+
+    private WorkspaceCapabilityReadiness shellAccessReadiness() {
+        if (!workspaceProperties.shellAccess().enabled()) {
+            return WorkspaceCapabilityReadiness.UNAVAILABLE;
+        }
+        boolean hasIssuer = hasText(resourceServerProperties.getJwt().getIssuerUri());
+        boolean hasAudience = hasText(securityProperties.requiredAudience());
+        boolean hasClientId = hasText(securityProperties.clientId());
+        return hasIssuer && hasAudience && hasClientId
+                ? WorkspaceCapabilityReadiness.READY
+                : WorkspaceCapabilityReadiness.BLOCKED;
+    }
+
+    private List<String> actions(
+            OnboardingStatusResponse.InviteStatus invite,
+            OnboardingStatusResponse.ProfileStatus profile,
+            OnboardingStatusResponse.ModuleProvisioning modules) {
+        return Stream.of(
+                        invite.action(),
+                        profile.action(),
+                        modules.identity().action(),
+                        modules.profile().action(),
+                        modules.matrix().action(),
+                        modules.nextcloud().action())
+                .filter(this::hasText)
+                .distinct()
+                .toList();
+    }
+
+    private List<String> extractRealmRoles(Jwt jwt) {
+        Map<String, Object> realmAccess = jwt.getClaimAsMap("realm_access");
+        if (realmAccess == null) {
+            return List.of();
+        }
+        Object roles = realmAccess.get("roles");
+        if (!(roles instanceof Collection<?> roleValues)) {
+            return List.of();
+        }
+        return roleValues.stream()
+                .filter(String.class::isInstance)
+                .map(String.class::cast)
+                .map(String::trim)
+                .filter(role -> !role.isEmpty())
+                .sorted()
+                .toList();
+    }
+
+    private List<String> extractStringList(Jwt jwt, String claimName) {
+        Object claim = jwt.getClaims().get(claimName);
+        if (!(claim instanceof Collection<?> values)) {
+            return List.of();
+        }
+        return values.stream()
+                .filter(String.class::isInstance)
+                .map(String.class::cast)
+                .map(String::trim)
+                .filter(value -> !value.isEmpty())
+                .sorted()
+                .toList();
+    }
+
+    private List<String> productRoles(List<String> realmRoles) {
+        LinkedHashSet<String> roles = new LinkedHashSet<>();
+        for (String role : realmRoles) {
+            String normalized = role.toLowerCase(Locale.ROOT);
+            if (ROLE_PRIORITY.contains(normalized)) {
+                roles.add(normalized);
+            }
+        }
+        return ROLE_PRIORITY.stream()
+                .filter(roles::contains)
+                .toList();
+    }
+
+    private boolean emailVerified(Jwt jwt) {
+        Object value = jwt.getClaims().get("email_verified");
+        return value instanceof Boolean verified && verified;
+    }
+
+    private String firstText(String primary, String fallback) {
+        if (primary != null && !primary.isBlank()) {
+            return primary.trim();
+        }
+        return fallback;
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -82,3 +82,13 @@ weave:
     boards:
       enabled: ${WEAVE_WORKSPACE_BOARDS_ENABLED:false}
       readiness: ${WEAVE_WORKSPACE_BOARDS_READINESS:}
+  onboarding:
+    matrix:
+      # Optional first-run provisioning override. When blank, status is derived from
+      # the workspace chat capability. Accepted values: not_configured, pending,
+      # ready, degraded, failed.
+      provisioning-state: ${WEAVE_ONBOARDING_MATRIX_PROVISIONING_STATE:}
+    nextcloud:
+      # Optional first-run provisioning override. When blank, status is derived from
+      # the files/calendar capabilities and canonical Nextcloud route.
+      provisioning-state: ${WEAVE_ONBOARDING_NEXTCLOUD_PROVISIONING_STATE:}

--- a/src/test/java/com/massimotter/weave/backend/controller/OnboardingControllerTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/OnboardingControllerTest.java
@@ -1,0 +1,149 @@
+package com.massimotter.weave.backend.controller;
+
+import com.massimotter.weave.backend.config.ApiAccessDeniedHandler;
+import com.massimotter.weave.backend.config.ApiAuthenticationEntryPoint;
+import com.massimotter.weave.backend.config.ApiErrorResponseWriter;
+import com.massimotter.weave.backend.config.OnboardingStatusProperties;
+import com.massimotter.weave.backend.config.PlatformContractProperties;
+import com.massimotter.weave.backend.config.SecurityConfig;
+import com.massimotter.weave.backend.config.WeaveSecurityProperties;
+import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
+import com.massimotter.weave.backend.service.OnboardingStatusService;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = OnboardingController.class,
+        excludeAutoConfiguration = OAuth2ResourceServerAutoConfiguration.class)
+@Import({
+        SecurityConfig.class,
+        OnboardingStatusService.class,
+        ApiAuthenticationEntryPoint.class,
+        ApiAccessDeniedHandler.class,
+        ApiErrorResponseWriter.class
+})
+@EnableConfigurationProperties({
+        PlatformContractProperties.class,
+        WeaveSecurityProperties.class,
+        WorkspaceCapabilityProperties.class,
+        OnboardingStatusProperties.class,
+        OAuth2ResourceServerProperties.class
+})
+@TestPropertySource(properties = {
+        "spring.security.oauth2.resourceserver.jwt.issuer-uri=https://auth.weave.local/realms/weave",
+        "weave.workspace.chat.dependency-url=https://matrix.weave.local",
+        "weave.workspace.files.dependency-url=https://files.weave.local"
+})
+class OnboardingControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JwtDecoder jwtDecoder;
+
+    @Test
+    void returnsFirstRunStatusForAuthenticatedUser() throws Exception {
+        mockMvc.perform(get("/api/onboarding/status").with(jwt().jwt(jwt -> jwt
+                        .subject("user-123")
+                        .claim("preferred_username", "alice")
+                        .claim("name", "Alice Example")
+                        .claim("email", "alice@example.com")
+                        .claim("email_verified", true)
+                        .claim("locale", "en")
+                        .claim("timezone", "Europe/Berlin")
+                        .claim("aud", List.of("weave-app"))
+                        .claim("realm_access", Map.of("roles", List.of("member")))
+                        .claim("groups", List.of("workspace-default")))
+                        .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.identity.userId").value("user-123"))
+                .andExpect(jsonPath("$.identity.username").value("alice"))
+                .andExpect(jsonPath("$.identity.groups[0]").value("workspace-default"))
+                .andExpect(jsonPath("$.invite.status").value("active"))
+                .andExpect(jsonPath("$.access.primaryRole").value("member"))
+                .andExpect(jsonPath("$.profile.status").value("ready"))
+                .andExpect(jsonPath("$.moduleProvisioning.identity.state").value("ready"))
+                .andExpect(jsonPath("$.moduleProvisioning.profile.state").value("ready"))
+                .andExpect(jsonPath("$.moduleProvisioning.matrix.state").value("ready"))
+                .andExpect(jsonPath("$.moduleProvisioning.nextcloud.state").value("ready"))
+                .andExpect(jsonPath("$.firstRunComplete").value(true))
+                .andExpect(jsonPath("$.actions").isEmpty());
+    }
+
+    @ParameterizedTest
+    @MethodSource("roleMappings")
+    void mapsMvpRolesForFirstRunRouting(String realmRole, boolean canAdminister, boolean canInvite,
+            boolean canUseModules) throws Exception {
+        mockMvc.perform(get("/api/onboarding/status").with(jwt().jwt(jwt -> jwt
+                        .subject("user-123")
+                        .claim("preferred_username", realmRole + "-user")
+                        .claim("name", "Role User")
+                        .claim("email", realmRole + "@example.com")
+                        .claim("email_verified", true)
+                        .claim("aud", List.of("weave-app"))
+                        .claim("realm_access", Map.of("roles", List.of(realmRole))))
+                        .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.access.primaryRole").value(realmRole))
+                .andExpect(jsonPath("$.access.canAdministerWorkspace").value(canAdminister))
+                .andExpect(jsonPath("$.access.canInviteUsers").value(canInvite))
+                .andExpect(jsonPath("$.access.canUseWorkspaceModules").value(canUseModules));
+    }
+
+    @Test
+    void returnsPendingInviteAndProfileStatusWithoutRawDownstreamErrors() throws Exception {
+        mockMvc.perform(get("/api/onboarding/status").with(jwt().jwt(jwt -> jwt
+                        .subject("user-123")
+                        .claim("preferred_username", "alice")
+                        .claim("name", "Alice Example")
+                        .claim("email", "alice@example.com")
+                        .claim("email_verified", false)
+                        .claim("weave_invite_status", "pending")
+                        .claim("aud", List.of("weave-app"))
+                        .claim("realm_access", Map.of("roles", List.of("member"))))
+                        .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.invite.status").value("pending"))
+                .andExpect(jsonPath("$.profile.status").value("pending"))
+                .andExpect(jsonPath("$.profile.missing[0]").value("email_verified"))
+                .andExpect(jsonPath("$.moduleProvisioning.profile.state").value("pending"))
+                .andExpect(jsonPath("$.firstRunComplete").value(false))
+                .andExpect(jsonPath("$.actions[0]").isNotEmpty());
+    }
+
+    @Test
+    void rejectsAnonymousRequests() throws Exception {
+        mockMvc.perform(get("/api/onboarding/status"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    private static Stream<Arguments> roleMappings() {
+        return Stream.of(
+                Arguments.of("owner", true, true, true),
+                Arguments.of("admin", true, true, true),
+                Arguments.of("member", false, false, true),
+                Arguments.of("guest", false, false, false));
+    }
+}

--- a/src/test/java/com/massimotter/weave/backend/controller/OpenApiDocumentationTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/OpenApiDocumentationTest.java
@@ -36,6 +36,7 @@ class OpenApiDocumentationTest {
                 .andExpect(jsonPath("$.paths['/api/health/ready']").exists())
                 .andExpect(jsonPath("$.paths['/api/platform/config']").exists())
                 .andExpect(jsonPath("$.paths['/api/platform/status']").exists())
+                .andExpect(jsonPath("$.paths['/api/onboarding/status']").exists())
                 .andExpect(jsonPath("$.paths['/api/files']").exists())
                 .andExpect(jsonPath("$.paths['/api/files/upload']").exists())
                 .andExpect(jsonPath("$.paths['/api/files/folders']").exists())

--- a/src/test/java/com/massimotter/weave/backend/service/OnboardingStatusServiceTest.java
+++ b/src/test/java/com/massimotter/weave/backend/service/OnboardingStatusServiceTest.java
@@ -1,0 +1,86 @@
+package com.massimotter.weave.backend.service;
+
+import com.massimotter.weave.backend.config.OnboardingStatusProperties;
+import com.massimotter.weave.backend.config.PlatformContractProperties;
+import com.massimotter.weave.backend.config.WeaveSecurityProperties;
+import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
+import com.massimotter.weave.backend.model.OnboardingProvisioningState;
+import com.massimotter.weave.backend.model.OnboardingStatusResponse;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OnboardingStatusServiceTest {
+
+    @Test
+    void derivesNotConfiguredAndDegradedProvisioningStatesFromCapabilities() {
+        OAuth2ResourceServerProperties resourceServerProperties = new OAuth2ResourceServerProperties();
+        resourceServerProperties.getJwt().setIssuerUri("https://auth.weave.local/realms/weave");
+        OnboardingStatusService service = new OnboardingStatusService(
+                resourceServerProperties,
+                new WeaveSecurityProperties("weave-app", "weave-app"),
+                new WorkspaceCapabilityProperties(
+                        new WorkspaceCapabilityProperties.Capability(true, null, null),
+                        new WorkspaceCapabilityProperties.Capability(true, "https://matrix.weave.local", WorkspaceCapabilityReadiness.DEGRADED),
+                        new WorkspaceCapabilityProperties.Capability(false, null, null),
+                        new WorkspaceCapabilityProperties.Capability(false, null, null),
+                        new WorkspaceCapabilityProperties.Capability(false, null, null)),
+                new PlatformContractProperties(null, null, null, null, null, null, null, null),
+                new OnboardingStatusProperties(null, null));
+
+        OnboardingStatusResponse response = service.status(jwt(List.of("member")));
+
+        assertThat(response.moduleProvisioning().matrix().state()).isEqualTo(OnboardingProvisioningState.DEGRADED);
+        assertThat(response.moduleProvisioning().nextcloud().state()).isEqualTo(OnboardingProvisioningState.NOT_CONFIGURED);
+        assertThat(response.firstRunComplete()).isFalse();
+    }
+
+    @Test
+    void honorsExplicitPendingAndFailedProvisioningOverrides() {
+        OAuth2ResourceServerProperties resourceServerProperties = new OAuth2ResourceServerProperties();
+        resourceServerProperties.getJwt().setIssuerUri("https://auth.weave.local/realms/weave");
+        OnboardingStatusService service = new OnboardingStatusService(
+                resourceServerProperties,
+                new WeaveSecurityProperties("weave-app", "weave-app"),
+                new WorkspaceCapabilityProperties(
+                        new WorkspaceCapabilityProperties.Capability(true, null, null),
+                        new WorkspaceCapabilityProperties.Capability(true, "https://matrix.weave.local", null),
+                        new WorkspaceCapabilityProperties.Capability(true, "https://files.weave.local", null),
+                        new WorkspaceCapabilityProperties.Capability(false, null, null),
+                        new WorkspaceCapabilityProperties.Capability(false, null, null)),
+                new PlatformContractProperties(null, null, null, null, null, null, null, null),
+                new OnboardingStatusProperties(
+                        new OnboardingStatusProperties.ModuleProvisioning(OnboardingProvisioningState.PENDING),
+                        new OnboardingStatusProperties.ModuleProvisioning(OnboardingProvisioningState.FAILED)));
+
+        OnboardingStatusResponse response = service.status(jwt(List.of("member")));
+
+        assertThat(response.moduleProvisioning().matrix().state()).isEqualTo(OnboardingProvisioningState.PENDING);
+        assertThat(response.moduleProvisioning().nextcloud().state()).isEqualTo(OnboardingProvisioningState.FAILED);
+        assertThat(response.moduleProvisioning().matrix().message()).doesNotContain("Exception", "stack trace");
+        assertThat(response.moduleProvisioning().nextcloud().message()).doesNotContain("Exception", "stack trace");
+        assertThat(response.firstRunComplete()).isFalse();
+    }
+
+    private Jwt jwt(List<String> roles) {
+        Instant now = Instant.now();
+        return Jwt.withTokenValue("token")
+                .header("alg", "none")
+                .subject("user-123")
+                .issuedAt(now)
+                .expiresAt(now.plusSeconds(600))
+                .claim("preferred_username", "alice")
+                .claim("name", "Alice Example")
+                .claim("email", "alice@example.com")
+                .claim("email_verified", true)
+                .claim("aud", List.of("weave-app"))
+                .claim("realm_access", Map.of("roles", roles))
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary

Adds a protected first-run onboarding status endpoint for authenticated users so the app/admin flow can inspect invite activation, MVP role/group mapping, profile completeness, and Matrix/Nextcloud provisioning status without exposing downstream internals.

## Changes

- Added `GET /api/onboarding/status` with OpenAPI metadata.
- Added first-run status DTOs and service mapping identity/profile, invite status, owner/admin/member/guest access flags, and Matrix/Nextcloud provisioning states.
- Added optional provisioning override config for Matrix and Nextcloud: `not_configured`, `pending`, `ready`, `degraded`, `failed`.
- Updated README and release operations docs.
- Added controller/service tests, including owner/admin/member/guest role mapping and frontend-safe provisioning states.

## Testing

- `./gradlew test` ✅
- `./gradlew check` ✅

Fixes masssi164/weave-backend#32