### PR TITLE
fix(calendar): scope CalDAV facade to workspace calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Release 1 is an early operator-facing slice, not the full Teams/Slack migration 
 - first-run onboarding status at `/api/onboarding/status`
 - workspace capability and release-readiness snapshots at `/api/workspace/capabilities` and `/api/workspace/release-readiness`
 - Nextcloud-backed Files facade endpoints when a backend-owned actor is configured; otherwise they fail closed
-- Calendar facade endpoints mapped to Nextcloud CalDAV when backend actor credentials are configured; otherwise they fail closed
+- Calendar facade endpoints mapped to the backend actor's Nextcloud CalDAV workspace calendar when configured; unsafe private-user calendar templates fail closed
 - OpenAPI JSON at `/v3/api-docs`
 - Actuator health/info endpoints, Gradle wrapper, Dockerfile, and GitHub Actions CI
 

--- a/docs/runtime-configuration.md
+++ b/docs/runtime-configuration.md
@@ -59,13 +59,15 @@ If the actor model, username, or token is missing, files endpoints fail closed w
 Calendar product operations stay on `/api`; this backend is the only component that talks to Nextcloud CalDAV.
 
 - `WEAVE_CALDAV_BASE_URL`: Nextcloud origin used by the backend CalDAV adapter, defaults to `WEAVE_NEXTCLOUD_BASE_URL` or `https://files.weave.local`.
-- `WEAVE_CALDAV_CALENDAR_PATH_TEMPLATE`: CalDAV calendar collection template, defaults to `/remote.php/dav/calendars/{user}/personal/`; `{user}` is derived from authenticated token `preferred_username`, falling back to `sub`.
+- `WEAVE_CALDAV_CALENDAR_PATH_TEMPLATE`: CalDAV calendar collection path for the backend-owned workspace calendar, defaults to `/remote.php/dav/calendars/${WEAVE_CALDAV_BACKEND_USERNAME:-weave-backend}/personal/`.
 - `WEAVE_CALDAV_AUTH_MODE`: backend actor credential mode (`BASIC` or `BEARER`), defaults to `BASIC`.
 - `WEAVE_CALDAV_BACKEND_USERNAME`: backend actor username for Basic auth; required with `BASIC`.
 - `WEAVE_CALDAV_BACKEND_TOKEN`: backend actor app password/token or bearer token; required for the CalDAV adapter to call Nextcloud.
 - `WEAVE_CALDAV_REQUEST_TIMEOUT_SECONDS`: CalDAV request timeout, defaults to `10`.
 
-When required actor credentials are missing, calendar operations fail closed with `nextcloud-adapter-not-configured`. Recurrence creation, editing, and expansion are deferred: the current DTO has no RRULE contract, and the adapter does not expose raw recurrence fields. Recurring events returned by CalDAV may appear as their source VEVENT only until a later product/API spec defines full recurrence UX.
+The Release 1 calendar facade is explicitly scoped to the Weave workspace calendar owned by the backend actor. `WEAVE_CALDAV_CALENDAR_PATH_TEMPLATE` values containing `{user}` are treated as private-user calendar targets and fail closed with `nextcloud-adapter-not-configured` until a reviewed provisioning/sharing/delegated-token model is specified. The facade responses include `scope.type = "workspace"` so clients do not present this first slice as a private per-user calendar.
+
+When required actor credentials are missing or an unsafe private-user template is configured, calendar operations fail closed with `nextcloud-adapter-not-configured`. Recurrence creation, editing, and expansion are deferred: the current DTO has no RRULE contract, and the adapter does not expose raw recurrence fields. Recurring events returned by CalDAV may appear as their source VEVENT only until a later product/API spec defines full recurrence UX.
 
 ## Profile and onboarding variables
 

--- a/src/main/java/com/massimotter/weave/backend/config/CalendarCalDavProperties.java
+++ b/src/main/java/com/massimotter/weave/backend/config/CalendarCalDavProperties.java
@@ -14,7 +14,7 @@ public record CalendarCalDavProperties(
     public CalendarCalDavProperties {
         baseUrl = trimToNull(baseUrl);
         calendarPathTemplate = defaultIfBlank(calendarPathTemplate,
-                "/remote.php/dav/calendars/{user}/personal/");
+                "/remote.php/dav/calendars/weave-backend/personal/");
         authMode = authMode == null ? AuthMode.BASIC : authMode;
         backendUsername = trimToNull(backendUsername);
         backendToken = trimToNull(backendToken);
@@ -22,13 +22,21 @@ public record CalendarCalDavProperties(
     }
 
     public boolean isConfigured() {
-        if (baseUrl == null || !calendarPathTemplate.contains("{user}")) {
+        if (baseUrl == null || targetsPrivateUserCalendar()) {
             return false;
         }
         if (authMode == AuthMode.BEARER) {
             return backendToken != null;
         }
         return backendUsername != null && backendToken != null;
+    }
+
+    public boolean targetsPrivateUserCalendar() {
+        return calendarPathTemplate != null && calendarPathTemplate.contains("{user}");
+    }
+
+    public String calendarScope() {
+        return targetsPrivateUserCalendar() ? "private-user" : "workspace";
     }
 
     public enum AuthMode {

--- a/src/main/java/com/massimotter/weave/backend/model/calendar/CalendarEventResponse.java
+++ b/src/main/java/com/massimotter/weave/backend/model/calendar/CalendarEventResponse.java
@@ -22,5 +22,25 @@ public record CalendarEventResponse(
         @Schema(description = "Whether the event is all-day.")
         boolean allDay,
         @Schema(description = "Opaque revision token used for conflict detection when available.")
-        String etag) {
+        String etag,
+        @Schema(description = "Calendar scope used for this facade event.")
+        CalendarScopeResponse scope) {
+
+    public CalendarEventResponse(
+            String id,
+            String title,
+            String description,
+            OffsetDateTime startsAt,
+            OffsetDateTime endsAt,
+            String timezone,
+            String location,
+            boolean allDay,
+            String etag) {
+        this(id, title, description, startsAt, endsAt, timezone, location, allDay, etag,
+                CalendarScopeResponse.workspace());
+    }
+
+    public CalendarEventResponse {
+        scope = scope == null ? CalendarScopeResponse.workspace() : scope;
+    }
 }

--- a/src/main/java/com/massimotter/weave/backend/model/calendar/CalendarEventsResponse.java
+++ b/src/main/java/com/massimotter/weave/backend/model/calendar/CalendarEventsResponse.java
@@ -4,5 +4,16 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
 @Schema(description = "Calendar facade event listing response.")
-public record CalendarEventsResponse(List<CalendarEventResponse> events) {
+public record CalendarEventsResponse(
+        @Schema(description = "Calendar scope used for this facade response.")
+        CalendarScopeResponse scope,
+        List<CalendarEventResponse> events) {
+
+    public CalendarEventsResponse(List<CalendarEventResponse> events) {
+        this(CalendarScopeResponse.workspace(), events);
+    }
+
+    public CalendarEventsResponse {
+        scope = scope == null ? CalendarScopeResponse.workspace() : scope;
+    }
 }

--- a/src/main/java/com/massimotter/weave/backend/model/calendar/CalendarScopeResponse.java
+++ b/src/main/java/com/massimotter/weave/backend/model/calendar/CalendarScopeResponse.java
@@ -1,0 +1,15 @@
+package com.massimotter.weave.backend.model.calendar;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Calendar ownership scope exposed by the Weave calendar facade.")
+public record CalendarScopeResponse(
+        @Schema(description = "Stable scope identifier.", example = "workspace")
+        String type,
+        @Schema(description = "Human-readable scope label.", example = "Weave workspace calendar")
+        String label) {
+
+    public static CalendarScopeResponse workspace() {
+        return new CalendarScopeResponse("workspace", "Weave workspace calendar");
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/service/calendar/CalDavCalendarAdapter.java
+++ b/src/main/java/com/massimotter/weave/backend/service/calendar/CalDavCalendarAdapter.java
@@ -276,7 +276,11 @@ public class CalDavCalendarAdapter implements CalendarAdapter {
             throw new CalendarAdapterException(
                     CalendarAdapterException.Type.NOT_CONFIGURED,
                     "Calendar facade is available, but the downstream Nextcloud CalDAV adapter is not configured.",
-                    Map.of("module", "calendar", "operation", operation));
+                    Map.of(
+                            "module", "calendar",
+                            "operation", operation,
+                            "calendarScope", properties.calendarScope(),
+                            "privateUserTemplateAllowed", false));
         }
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,10 +56,12 @@ weave:
   calendar:
     caldav:
       # Calendar product operations stay on /api; this backend actor is the only component
-      # that talks to Nextcloud CalDAV. Leave credentials blank to fail safely with a
-      # normalized nextcloud-adapter-not-configured error until the actor/token model is wired.
+      # that talks to Nextcloud CalDAV. The first safe slice targets a backend-owned
+      # workspace calendar; private per-user templates containing {user} fail closed until
+      # a delegated/sharing access model is contracted. Leave credentials blank to fail
+      # safely with a normalized nextcloud-adapter-not-configured error until wired.
       base-url: ${WEAVE_CALDAV_BASE_URL:${WEAVE_NEXTCLOUD_BASE_URL:https://files.weave.local}}
-      calendar-path-template: ${WEAVE_CALDAV_CALENDAR_PATH_TEMPLATE:/remote.php/dav/calendars/{user}/personal/}
+      calendar-path-template: ${WEAVE_CALDAV_CALENDAR_PATH_TEMPLATE:/remote.php/dav/calendars/${WEAVE_CALDAV_BACKEND_USERNAME:weave-backend}/personal/}
       auth-mode: ${WEAVE_CALDAV_AUTH_MODE:BASIC}
       backend-username: ${WEAVE_CALDAV_BACKEND_USERNAME:}
       backend-token: ${WEAVE_CALDAV_BACKEND_TOKEN:}

--- a/src/test/java/com/massimotter/weave/backend/service/CalendarFacadeServiceTest.java
+++ b/src/test/java/com/massimotter/weave/backend/service/CalendarFacadeServiceTest.java
@@ -44,6 +44,7 @@ class CalendarFacadeServiceTest {
 
         var response = service(adapter).list(startsAt.minusDays(1), endsAt.plusDays(1));
 
+        assertThat(response.scope().type()).isEqualTo("workspace");
         assertThat(response.events()).containsExactly(event);
         assertThat(capturedPrincipal.get().subject()).isEqualTo("user-123");
         assertThat(capturedPrincipal.get().nextcloudUserId()).isEqualTo("massimo");

--- a/src/test/java/com/massimotter/weave/backend/service/calendar/CalDavCalendarAdapterTest.java
+++ b/src/test/java/com/massimotter/weave/backend/service/calendar/CalDavCalendarAdapterTest.java
@@ -40,15 +40,37 @@ class CalDavCalendarAdapterTest {
     }
 
     @Test
+    void rejectsPrivateUserCalendarTemplatesUntilAccessModelIsContracted() {
+        CalDavCalendarAdapter adapter = new CalDavCalendarAdapter(new CalendarCalDavProperties(
+                "https://files.weave.local",
+                "/remote.php/dav/calendars/{user}/personal/",
+                CalendarCalDavProperties.AuthMode.BASIC,
+                "weave-backend",
+                "secret",
+                1));
+
+        assertThatThrownBy(() -> adapter.list(principal(), null, null))
+                .isInstanceOf(CalendarAdapterException.class)
+                .satisfies(error -> {
+                    CalendarAdapterException adapterError = (CalendarAdapterException) error;
+                    assertThat(adapterError.type()).isEqualTo(CalendarAdapterException.Type.NOT_CONFIGURED);
+                    assertThat(adapterError.details()).containsEntry("calendarScope", "private-user");
+                    assertThat(adapterError.details()).containsEntry("privateUserTemplateAllowed", false);
+                });
+    }
+
+    @Test
     void listsEventsWithCalDavCalendarQuery() throws Exception {
         List<String> methods = new ArrayList<>();
+        List<String> paths = new ArrayList<>();
         server = server(exchange -> {
             methods.add(exchange.getRequestMethod());
+            paths.add(exchange.getRequestURI().getRawPath());
             String response = """
                     <?xml version="1.0" encoding="utf-8"?>
                     <d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
                       <d:response>
-                        <d:href>/remote.php/dav/calendars/massimo/personal/planning.ics</d:href>
+                        <d:href>/remote.php/dav/calendars/weave-backend/personal/planning.ics</d:href>
                         <d:propstat><d:prop>
                           <d:getetag>\"etag-1\"</d:getetag>
                           <c:calendar-data>BEGIN:VCALENDAR&#13;
@@ -73,9 +95,11 @@ END:VCALENDAR&#13;
                 OffsetDateTime.parse("2026-04-27T00:00:00+02:00"));
 
         assertThat(methods).containsExactly("REPORT");
+        assertThat(paths).containsExactly("/remote.php/dav/calendars/weave-backend/personal/");
         assertThat(events).hasSize(1);
         assertThat(events.get(0).title()).isEqualTo("Planning");
         assertThat(events.get(0).etag()).isEqualTo("\"etag-1\"");
+        assertThat(events.get(0).scope().type()).isEqualTo("workspace");
     }
 
     @Test
@@ -127,7 +151,7 @@ END:VCALENDAR&#13;
     private CalDavCalendarAdapter adapter() {
         return new CalDavCalendarAdapter(new CalendarCalDavProperties(
                 "http://localhost:" + server.getAddress().getPort(),
-                "/remote.php/dav/calendars/{user}/personal/",
+                "/remote.php/dav/calendars/weave-backend/personal/",
                 CalendarCalDavProperties.AuthMode.BASIC,
                 "backend",
                 "secret",


### PR DESCRIPTION
## Problem

Release 1 Calendar must not imply that the backend actor can access arbitrary private user calendars by expanding `/remote.php/dav/calendars/{user}/personal/`. Infra PR #53 now points the stack at a backend-owned calendar, but the backend still accepted `{user}` templates and response bodies did not identify the first slice as workspace-scoped.

## Target behavior

- Calendar facade defaults to the backend actor workspace calendar path.
- CalDAV templates containing `{user}` fail closed as `nextcloud-adapter-not-configured` until a reviewed private-calendar access model exists.
- Calendar list/event responses include `scope.type = "workspace"` so clients can label this honestly.
- Runtime docs and README clarify the backend actor/workspace-calendar boundary.

## Files changed

- `src/main/java/.../CalendarCalDavProperties.java`
- `src/main/java/.../CalDavCalendarAdapter.java`
- `src/main/java/.../model/calendar/*`
- `src/main/resources/application.yml`
- calendar service/adapter tests
- backend README/runtime configuration docs

## Validation

- `./gradlew test --tests '*Calendar*'` ✅
- `./gradlew test` ✅
- `git diff --check` ✅

## Contract impact

Adds additive `scope` metadata to calendar facade responses. Private per-user CalDAV remains blocked until the access model is specified and tested.

Part of masssi164/weave-backend#52.
