### PR TITLE
feat(boards): add provider-neutral preview contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Release 1 is an early operator-facing slice, not the full Teams/Slack migration 
 - OpenAPI JSON at `/v3/api-docs`
 - Actuator health/info endpoints, Gradle wrapper, Dockerfile, and GitHub Actions CI
 
-Release 1 does **not** claim a complete Teams/Slack replacement, end-user credential brokering, full Matrix/Nextcloud provisioning automation, recurrence-rich calendar UX, sharing/move policy, or the future Weaver intelligence layer. Those remain product-roadmap items behind explicit contracts.
+Release 1 does **not** claim a complete Teams/Slack replacement, end-user credential brokering, full Matrix/Nextcloud provisioning automation, recurrence-rich calendar UX, sharing/move policy, Boards/Tasks product navigation, or the future Weaver intelligence layer. Those remain product-roadmap items behind explicit contracts. The hidden Boards/Tasks preview contract is documented separately in [docs/boards-preview-contract.md](docs/boards-preview-contract.md) and must not be treated as a Release 1 enabled surface.
 
 ## Product boundary
 
@@ -47,6 +47,7 @@ Avoid using it to replace standards-based native flows by default:
 - `docs/runtime-configuration.md`: complete environment-variable reference and fail-closed adapter behavior.
 - `docs/release-operations.md`: Release 1 API operations guide and minimum operator checks.
 - `docs/architecture-alignment.md`: cross-repo responsibility split for app, backend, and infrastructure.
+- `docs/boards-preview-contract.md`: hidden, post-Release-1 Boards/Tasks provider-neutral contract notes; not a Product screenshots or Release 1 surface.
 - `docs/issues/`: historical alignment issue drafts.
 
 ## Quick start

--- a/docs/boards-preview-contract.md
+++ b/docs/boards-preview-contract.md
@@ -1,0 +1,51 @@
+# Boards/Tasks preview contract
+
+Boards/Tasks is a provider-neutral, post-Release-1 preview slice. It is **not** a Release 1 product surface, has no published backend routes, and must remain hidden/feature-flagged until a later promotion spec defines API routes, auth scopes, DTO compatibility, OpenAPI publication, runtime provider setup, smoke/E2E, and accessibility gates.
+
+This document is intentionally separate from Release 1 screenshots and product-surface documentation. Do not add Boards/Tasks screenshots to the main Product screenshots section unless the module is fully navigable and release-enabled by a later spec.
+
+## Scope in this backend slice
+
+Implemented now:
+
+- Provider-neutral Java domain records for projects, boards, columns, tasks, labels, comments, attachments, provider refs, capabilities, and normalized events.
+- A repository port that hides provider pagination, IDs, vocabulary, and raw errors from callers.
+- A support-safe error vocabulary aligned with the workspace spec.
+- A no-op event publisher boundary plus preview JSON/OpenAPI schema artifacts under `src/main/resources/contracts/`.
+- A first Vikunja adapter boundary and mapper that translates Vikunja projects/buckets/tasks into Weave concepts.
+- A fail-closed Vikunja repository placeholder that advertises preview capabilities but does not perform runtime HTTP calls.
+
+Not implemented now:
+
+- No Spring MVC controller routes.
+- No Release 1 navigation or product enablement.
+- No provider runtime configuration, secrets, Caddy routes, or smoke checks.
+- No user-facing screenshots.
+- No notifications, audit streams, webhooks, or automation consumers.
+
+## Provider-neutral model
+
+The Weave model follows `../specs/14-boards-tasks-domain-and-provider-adapter-contract.md`:
+
+- `WeaveProject` maps to a provider project/workspace grouping.
+- `Board` is the Weave-owned board concept.
+- `BoardColumn` maps provider lists/buckets/statuses into `not_started`, `in_progress`, `blocked`, `done`, or `archived`.
+- `TaskItem` is the provider-neutral task/card shape consumed by future API/UI work.
+- `ProviderRef` preserves provider IDs, URLs, etags, versions, and sync timestamps for diagnostics, export, migration, and conflict handling without making those references the primary product identity.
+
+## Vikunja first adapter boundary
+
+Vikunja is the first strategic adapter boundary because it is lightweight, self-hostable, and API-oriented. The current mapper translates:
+
+- Vikunja project → Weave project and board
+- Vikunja bucket → Weave board column
+- Vikunja task → Weave task item
+
+The repository placeholder fails closed with `provider_unavailable` until a promotion spec defines authentication, HTTP client behavior, persistence/sync expectations, route DTOs, and validation gates.
+
+## Contract artifacts
+
+- `src/main/resources/contracts/boards-preview.openapi.yaml` contains preview schema components only and intentionally has `paths: {}`.
+- `src/main/resources/contracts/task-board-event.schema.json` contains the preview normalized event envelope.
+
+These artifacts are open contract drafts for implementation alignment; they are not a published Release 1 API surface.

--- a/src/main/java/com/massimotter/weave/backend/boards/domain/AttachmentKind.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/domain/AttachmentKind.java
@@ -1,0 +1,6 @@
+package com.massimotter.weave.backend.boards.domain;
+
+public enum AttachmentKind {
+    FILE,
+    LINK
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/domain/Board.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/domain/Board.java
@@ -1,0 +1,21 @@
+package com.massimotter.weave.backend.boards.domain;
+
+import java.util.List;
+
+public record Board(
+        String id,
+        String projectId,
+        String name,
+        String description,
+        List<BoardColumn> columns,
+        boolean archived,
+        List<ProviderRef> providerRefs) {
+
+    public Board {
+        id = BoardsContract.requireText(id, "id");
+        projectId = BoardsContract.requireText(projectId, "projectId");
+        name = BoardsContract.requireText(name, "name");
+        columns = BoardsContract.immutableList(columns, "columns");
+        providerRefs = BoardsContract.immutableList(providerRefs, "providerRefs");
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/domain/BoardCapability.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/domain/BoardCapability.java
@@ -1,0 +1,22 @@
+package com.massimotter.weave.backend.boards.domain;
+
+public enum BoardCapability {
+    COMMENTS("comments"),
+    ATTACHMENTS("attachments"),
+    NON_DESTRUCTIVE_ARCHIVE("non_destructive_archive"),
+    WEBHOOK_EVENTS("webhook_events"),
+    INCREMENTAL_SYNC("incremental_sync"),
+    CHECKLISTS("checklists"),
+    CUSTOM_FIELDS("custom_fields"),
+    ACCESSIBLE_NON_DRAG_MOVES("accessible_non_drag_moves");
+
+    private final String contractName;
+
+    BoardCapability(String contractName) {
+        this.contractName = contractName;
+    }
+
+    public String contractName() {
+        return contractName;
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/domain/BoardColumn.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/domain/BoardColumn.java
@@ -1,0 +1,29 @@
+package com.massimotter.weave.backend.boards.domain;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public record BoardColumn(
+        String id,
+        String boardId,
+        String name,
+        int position,
+        ColumnSemanticStatus semanticStatus,
+        Integer wipLimit,
+        List<ProviderRef> providerRefs) {
+
+    public BoardColumn {
+        id = BoardsContract.requireText(id, "id");
+        boardId = BoardsContract.requireText(boardId, "boardId");
+        name = BoardsContract.requireText(name, "name");
+        if (position < 0) {
+            throw new IllegalArgumentException("position must not be negative");
+        }
+        semanticStatus = requireNonNull(semanticStatus, "semanticStatus must not be null");
+        if (wipLimit != null && wipLimit < 1) {
+            throw new IllegalArgumentException("wipLimit must be positive when present");
+        }
+        providerRefs = BoardsContract.immutableList(providerRefs, "providerRefs");
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/domain/BoardProviderCapabilities.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/domain/BoardProviderCapabilities.java
@@ -1,0 +1,27 @@
+package com.massimotter.weave.backend.boards.domain;
+
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public record BoardProviderCapabilities(
+        ProviderKind provider,
+        boolean enabled,
+        Set<BoardCapability> supported,
+        Set<BoardCapability> unsupported,
+        String supportSafeSummary) {
+
+    public BoardProviderCapabilities {
+        provider = requireNonNull(provider, "provider must not be null");
+        supported = BoardsContract.immutableSet(supported, "supported");
+        unsupported = BoardsContract.immutableSet(unsupported, "unsupported");
+        if (!supported.stream().filter(unsupported::contains).toList().isEmpty()) {
+            throw new IllegalArgumentException("supported and unsupported capabilities must not overlap");
+        }
+        supportSafeSummary = BoardsContract.requireText(supportSafeSummary, "supportSafeSummary");
+    }
+
+    public boolean supports(BoardCapability capability) {
+        return supported.contains(capability);
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/domain/BoardsContract.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/domain/BoardsContract.java
@@ -1,0 +1,41 @@
+package com.massimotter.weave.backend.boards.domain;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+
+final class BoardsContract {
+
+    private BoardsContract() {
+    }
+
+    static String requireText(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+        return value;
+    }
+
+    static URI optionalUri(URI value) {
+        return value;
+    }
+
+    static Instant optionalInstant(Instant value) {
+        return value;
+    }
+
+    static <T> List<T> immutableList(List<T> value, String field) {
+        if (value == null) {
+            throw new IllegalArgumentException(field + " must not be null");
+        }
+        return List.copyOf(value);
+    }
+
+    static <T> Set<T> immutableSet(Set<T> value, String field) {
+        if (value == null) {
+            throw new IllegalArgumentException(field + " must not be null");
+        }
+        return Set.copyOf(value);
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/domain/ColumnSemanticStatus.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/domain/ColumnSemanticStatus.java
@@ -1,0 +1,19 @@
+package com.massimotter.weave.backend.boards.domain;
+
+public enum ColumnSemanticStatus {
+    NOT_STARTED("not_started"),
+    IN_PROGRESS("in_progress"),
+    BLOCKED("blocked"),
+    DONE("done"),
+    ARCHIVED("archived");
+
+    private final String contractName;
+
+    ColumnSemanticStatus(String contractName) {
+        this.contractName = contractName;
+    }
+
+    public String contractName() {
+        return contractName;
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/domain/EventRedactionLevel.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/domain/EventRedactionLevel.java
@@ -1,0 +1,8 @@
+package com.massimotter.weave.backend.boards.domain;
+
+public enum EventRedactionLevel {
+    PUBLIC_METADATA,
+    WORKSPACE_INTERNAL,
+    SUPPORT_SAFE,
+    PRIVATE_CONTENT
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/domain/Label.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/domain/Label.java
@@ -1,0 +1,17 @@
+package com.massimotter.weave.backend.boards.domain;
+
+import java.util.List;
+
+public record Label(
+        String id,
+        String name,
+        String color,
+        String description,
+        List<ProviderRef> providerRefs) {
+
+    public Label {
+        id = BoardsContract.requireText(id, "id");
+        name = BoardsContract.requireText(name, "name");
+        providerRefs = BoardsContract.immutableList(providerRefs, "providerRefs");
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/domain/ProjectVisibility.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/domain/ProjectVisibility.java
@@ -1,0 +1,7 @@
+package com.massimotter.weave.backend.boards.domain;
+
+public enum ProjectVisibility {
+    PRIVATE,
+    WORKSPACE,
+    PUBLIC
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/domain/ProviderKind.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/domain/ProviderKind.java
@@ -1,0 +1,23 @@
+package com.massimotter.weave.backend.boards.domain;
+
+/**
+ * Provider identity used only for diagnostics, export, migration, and sync metadata.
+ * User-facing Boards language stays Weave-owned and provider-neutral.
+ */
+public enum ProviderKind {
+    VIKUNJA("vikunja"),
+    OPEN_PROJECT("openproject"),
+    NEXTCLOUD_DECK("nextcloud-deck"),
+    IN_MEMORY("in-memory"),
+    UNKNOWN("unknown");
+
+    private final String contractName;
+
+    ProviderKind(String contractName) {
+        this.contractName = contractName;
+    }
+
+    public String contractName() {
+        return contractName;
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/domain/ProviderRef.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/domain/ProviderRef.java
@@ -1,0 +1,26 @@
+package com.massimotter.weave.backend.boards.domain;
+
+import java.net.URI;
+import java.time.Instant;
+
+import static java.util.Objects.requireNonNull;
+
+public record ProviderRef(
+        ProviderKind provider,
+        String externalId,
+        URI externalUrl,
+        String version,
+        String etag,
+        Instant lastSyncedAt) {
+
+    public ProviderRef {
+        provider = requireNonNull(provider, "provider must not be null");
+        externalId = BoardsContract.requireText(externalId, "externalId");
+        externalUrl = BoardsContract.optionalUri(externalUrl);
+        lastSyncedAt = BoardsContract.optionalInstant(lastSyncedAt);
+    }
+
+    public static ProviderRef of(ProviderKind provider, String externalId) {
+        return new ProviderRef(provider, externalId, null, null, null, null);
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/domain/TaskAttachment.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/domain/TaskAttachment.java
@@ -1,0 +1,29 @@
+package com.massimotter.weave.backend.boards.domain;
+
+import java.net.URI;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public record TaskAttachment(
+        String id,
+        String taskId,
+        AttachmentKind kind,
+        String displayName,
+        URI uri,
+        Long size,
+        String mimeType,
+        List<ProviderRef> providerRefs) {
+
+    public TaskAttachment {
+        id = BoardsContract.requireText(id, "id");
+        taskId = BoardsContract.requireText(taskId, "taskId");
+        kind = requireNonNull(kind, "kind must not be null");
+        displayName = BoardsContract.requireText(displayName, "displayName");
+        uri = requireNonNull(uri, "uri must not be null");
+        if (size != null && size < 0) {
+            throw new IllegalArgumentException("size must not be negative");
+        }
+        providerRefs = BoardsContract.immutableList(providerRefs, "providerRefs");
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/domain/TaskBoardEvent.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/domain/TaskBoardEvent.java
@@ -1,0 +1,30 @@
+package com.massimotter.weave.backend.boards.domain;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public record TaskBoardEvent(
+        String idempotencyKey,
+        TaskBoardEventType type,
+        String actorRef,
+        Instant occurredAt,
+        String workspaceId,
+        String projectId,
+        String boardId,
+        String taskId,
+        ProviderRef providerRef,
+        EventRedactionLevel redactionLevel,
+        Map<String, Object> payload) {
+
+    public TaskBoardEvent {
+        idempotencyKey = BoardsContract.requireText(idempotencyKey, "idempotencyKey");
+        type = requireNonNull(type, "type must not be null");
+        actorRef = BoardsContract.requireText(actorRef, "actorRef");
+        occurredAt = requireNonNull(occurredAt, "occurredAt must not be null");
+        workspaceId = BoardsContract.requireText(workspaceId, "workspaceId");
+        redactionLevel = requireNonNull(redactionLevel, "redactionLevel must not be null");
+        payload = Map.copyOf(requireNonNull(payload, "payload must not be null"));
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/domain/TaskBoardEventType.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/domain/TaskBoardEventType.java
@@ -1,0 +1,26 @@
+package com.massimotter.weave.backend.boards.domain;
+
+public enum TaskBoardEventType {
+    TASK_CREATED("task.created"),
+    TASK_UPDATED("task.updated"),
+    TASK_COMPLETED("task.completed"),
+    TASK_ARCHIVED("task.archived"),
+    TASK_MOVED("task.moved"),
+    ASSIGNMENT_CHANGED("assignment.changed"),
+    LABEL_CHANGED("label.changed"),
+    PRIORITY_CHANGED("priority.changed"),
+    DUE_DATE_CHANGED("due_date.changed"),
+    COMMENT_ADDED("comment.added"),
+    ATTACHMENT_CHANGED("attachment.changed"),
+    SYNC_CONFLICT_DETECTED("sync.conflict_detected");
+
+    private final String contractName;
+
+    TaskBoardEventType(String contractName) {
+        this.contractName = contractName;
+    }
+
+    public String contractName() {
+        return contractName;
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/domain/TaskComment.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/domain/TaskComment.java
@@ -1,0 +1,25 @@
+package com.massimotter.weave.backend.boards.domain;
+
+import java.time.Instant;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public record TaskComment(
+        String id,
+        String taskId,
+        String actorRef,
+        String body,
+        Instant createdAt,
+        Instant editedAt,
+        List<ProviderRef> providerRefs) {
+
+    public TaskComment {
+        id = BoardsContract.requireText(id, "id");
+        taskId = BoardsContract.requireText(taskId, "taskId");
+        actorRef = BoardsContract.requireText(actorRef, "actorRef");
+        body = BoardsContract.requireText(body, "body");
+        createdAt = requireNonNull(createdAt, "createdAt must not be null");
+        providerRefs = BoardsContract.immutableList(providerRefs, "providerRefs");
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/domain/TaskItem.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/domain/TaskItem.java
@@ -1,0 +1,77 @@
+package com.massimotter.weave.backend.boards.domain;
+
+import java.time.Instant;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public record TaskItem(
+        String id,
+        String boardId,
+        String columnId,
+        String title,
+        String description,
+        TaskStatus status,
+        int position,
+        List<String> assigneeRefs,
+        List<String> labelRefs,
+        TaskPriority priority,
+        Instant startAt,
+        Instant dueAt,
+        Instant completedAt,
+        Instant updatedAt,
+        List<ProviderRef> providerRefs) {
+
+    public TaskItem {
+        id = BoardsContract.requireText(id, "id");
+        boardId = BoardsContract.requireText(boardId, "boardId");
+        columnId = BoardsContract.requireText(columnId, "columnId");
+        title = BoardsContract.requireText(title, "title");
+        status = requireNonNull(status, "status must not be null");
+        if (position < 0) {
+            throw new IllegalArgumentException("position must not be negative");
+        }
+        assigneeRefs = BoardsContract.immutableList(assigneeRefs, "assigneeRefs");
+        labelRefs = BoardsContract.immutableList(labelRefs, "labelRefs");
+        updatedAt = requireNonNull(updatedAt, "updatedAt must not be null");
+        providerRefs = BoardsContract.immutableList(providerRefs, "providerRefs");
+    }
+
+    public TaskItem moveTo(String targetColumnId, int targetPosition, Instant changedAt) {
+        return new TaskItem(
+                id,
+                boardId,
+                BoardsContract.requireText(targetColumnId, "targetColumnId"),
+                title,
+                description,
+                status,
+                targetPosition,
+                assigneeRefs,
+                labelRefs,
+                priority,
+                startAt,
+                dueAt,
+                completedAt,
+                requireNonNull(changedAt, "changedAt must not be null"),
+                providerRefs);
+    }
+
+    public TaskItem complete(Instant changedAt) {
+        return new TaskItem(
+                id,
+                boardId,
+                columnId,
+                title,
+                description,
+                TaskStatus.COMPLETED,
+                position,
+                assigneeRefs,
+                labelRefs,
+                priority,
+                startAt,
+                dueAt,
+                requireNonNull(changedAt, "changedAt must not be null"),
+                requireNonNull(changedAt, "changedAt must not be null"),
+                providerRefs);
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/domain/TaskPriority.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/domain/TaskPriority.java
@@ -1,0 +1,8 @@
+package com.massimotter.weave.backend.boards.domain;
+
+public enum TaskPriority {
+    LOW,
+    NORMAL,
+    HIGH,
+    URGENT
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/domain/TaskStatus.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/domain/TaskStatus.java
@@ -1,0 +1,18 @@
+package com.massimotter.weave.backend.boards.domain;
+
+public enum TaskStatus {
+    OPEN("open"),
+    BLOCKED("blocked"),
+    COMPLETED("completed"),
+    ARCHIVED("archived");
+
+    private final String contractName;
+
+    TaskStatus(String contractName) {
+        this.contractName = contractName;
+    }
+
+    public String contractName() {
+        return contractName;
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/domain/WeaveProject.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/domain/WeaveProject.java
@@ -1,0 +1,21 @@
+package com.massimotter.weave.backend.boards.domain;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public record WeaveProject(
+        String id,
+        String name,
+        ProjectVisibility visibility,
+        List<String> memberRefs,
+        List<ProviderRef> providerRefs) {
+
+    public WeaveProject {
+        id = BoardsContract.requireText(id, "id");
+        name = BoardsContract.requireText(name, "name");
+        visibility = requireNonNull(visibility, "visibility must not be null");
+        memberRefs = BoardsContract.immutableList(memberRefs, "memberRefs");
+        providerRefs = BoardsContract.immutableList(providerRefs, "providerRefs");
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/port/BoardPage.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/port/BoardPage.java
@@ -1,0 +1,16 @@
+package com.massimotter.weave.backend.boards.port;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public record BoardPage<T>(List<T> items, String nextCursor) {
+
+    public BoardPage {
+        items = List.copyOf(requireNonNull(items, "items must not be null"));
+    }
+
+    public static <T> BoardPage<T> singlePage(List<T> items) {
+        return new BoardPage<>(items, null);
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/port/BoardQuery.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/port/BoardQuery.java
@@ -1,0 +1,17 @@
+package com.massimotter.weave.backend.boards.port;
+
+public record BoardQuery(String cursor, int limit) {
+
+    public static final int DEFAULT_LIMIT = 50;
+    public static final int MAX_LIMIT = 250;
+
+    public BoardQuery {
+        if (limit < 1 || limit > MAX_LIMIT) {
+            throw new IllegalArgumentException("limit must be between 1 and " + MAX_LIMIT);
+        }
+    }
+
+    public static BoardQuery firstPage() {
+        return new BoardQuery(null, DEFAULT_LIMIT);
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/port/BoardsPreviewGuard.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/port/BoardsPreviewGuard.java
@@ -1,0 +1,31 @@
+package com.massimotter.weave.backend.boards.port;
+
+import com.massimotter.weave.backend.boards.support.BoardsErrorCode;
+import com.massimotter.weave.backend.boards.support.BoardsException;
+
+/**
+ * Central guard for the post-Release-1 Boards/Tasks slice. Keeping this guard near
+ * the repository port prevents exploratory adapters from accidentally becoming a
+ * reachable product API before a promotion spec defines routes, auth scopes, DTOs,
+ * OpenAPI publication, smoke, E2E, and accessibility gates.
+ */
+public final class BoardsPreviewGuard {
+
+    private final boolean enabled;
+
+    public BoardsPreviewGuard(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public void requireEnabled() {
+        if (!enabled) {
+            throw new BoardsException(
+                    BoardsErrorCode.PROVIDER_UNAVAILABLE,
+                    "Boards and tasks are a hidden preview module and are not enabled for Release 1.");
+        }
+    }
+
+    public boolean enabled() {
+        return enabled;
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/port/BoardsRepository.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/port/BoardsRepository.java
@@ -1,0 +1,44 @@
+package com.massimotter.weave.backend.boards.port;
+
+import com.massimotter.weave.backend.boards.domain.Board;
+import com.massimotter.weave.backend.boards.domain.BoardColumn;
+import com.massimotter.weave.backend.boards.domain.BoardProviderCapabilities;
+import com.massimotter.weave.backend.boards.domain.Label;
+import com.massimotter.weave.backend.boards.domain.TaskAttachment;
+import com.massimotter.weave.backend.boards.domain.TaskComment;
+import com.massimotter.weave.backend.boards.domain.TaskItem;
+import com.massimotter.weave.backend.boards.domain.WeaveProject;
+
+import java.util.Optional;
+
+/**
+ * Provider-neutral Boards repository contract. Implementations may talk to Vikunja,
+ * a future connector, or an in-memory fixture, but callers must not depend on
+ * provider-specific vocabulary, IDs, pagination, or errors.
+ */
+public interface BoardsRepository {
+
+    BoardProviderCapabilities capabilities();
+
+    BoardPage<WeaveProject> listProjects(BoardQuery query);
+
+    BoardPage<Board> listBoards(String projectId, BoardQuery query);
+
+    Optional<Board> findBoard(String boardId);
+
+    BoardPage<BoardColumn> listColumns(String boardId, BoardQuery query);
+
+    BoardPage<TaskItem> listTasks(String boardId, TaskQuery query);
+
+    BoardPage<Label> listLabels(String boardId, BoardQuery query);
+
+    BoardPage<TaskComment> listComments(String taskId, BoardQuery query);
+
+    BoardPage<TaskAttachment> listAttachments(String taskId, BoardQuery query);
+
+    TaskItem createTask(CreateTaskCommand command);
+
+    TaskItem moveTask(MoveTaskCommand command);
+
+    TaskItem completeTask(String taskId);
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/port/CreateTaskCommand.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/port/CreateTaskCommand.java
@@ -1,0 +1,28 @@
+package com.massimotter.weave.backend.boards.port;
+
+import java.time.Instant;
+import java.util.List;
+
+public record CreateTaskCommand(
+        String boardId,
+        String columnId,
+        String title,
+        String description,
+        List<String> assigneeRefs,
+        List<String> labelRefs,
+        Instant dueAt) {
+
+    public CreateTaskCommand {
+        if (boardId == null || boardId.isBlank()) {
+            throw new IllegalArgumentException("boardId must not be blank");
+        }
+        if (columnId == null || columnId.isBlank()) {
+            throw new IllegalArgumentException("columnId must not be blank");
+        }
+        if (title == null || title.isBlank()) {
+            throw new IllegalArgumentException("title must not be blank");
+        }
+        assigneeRefs = List.copyOf(assigneeRefs == null ? List.of() : assigneeRefs);
+        labelRefs = List.copyOf(labelRefs == null ? List.of() : labelRefs);
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/port/MoveTaskCommand.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/port/MoveTaskCommand.java
@@ -1,0 +1,16 @@
+package com.massimotter.weave.backend.boards.port;
+
+public record MoveTaskCommand(String taskId, String targetColumnId, int targetPosition) {
+
+    public MoveTaskCommand {
+        if (taskId == null || taskId.isBlank()) {
+            throw new IllegalArgumentException("taskId must not be blank");
+        }
+        if (targetColumnId == null || targetColumnId.isBlank()) {
+            throw new IllegalArgumentException("targetColumnId must not be blank");
+        }
+        if (targetPosition < 0) {
+            throw new IllegalArgumentException("targetPosition must not be negative");
+        }
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/port/NoopTaskBoardEventPublisher.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/port/NoopTaskBoardEventPublisher.java
@@ -1,0 +1,17 @@
+package com.massimotter.weave.backend.boards.port;
+
+import com.massimotter.weave.backend.boards.domain.TaskBoardEvent;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Safe default for the hidden Boards preview slice. It validates the event envelope
+ * without enabling notifications, audit streams, webhooks, or Release 1 behavior.
+ */
+public final class NoopTaskBoardEventPublisher implements TaskBoardEventPublisher {
+
+    @Override
+    public void publish(TaskBoardEvent event) {
+        requireNonNull(event, "event must not be null");
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/port/TaskBoardEventPublisher.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/port/TaskBoardEventPublisher.java
@@ -1,0 +1,13 @@
+package com.massimotter.weave.backend.boards.port;
+
+import com.massimotter.weave.backend.boards.domain.TaskBoardEvent;
+
+/**
+ * Event boundary for future automation, recent activity, audit, and support diagnostics.
+ * Implementations must preserve idempotency and redaction semantics before events leave
+ * the backend process.
+ */
+public interface TaskBoardEventPublisher {
+
+    void publish(TaskBoardEvent event);
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/port/TaskQuery.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/port/TaskQuery.java
@@ -1,0 +1,16 @@
+package com.massimotter.weave.backend.boards.port;
+
+import com.massimotter.weave.backend.boards.domain.TaskStatus;
+
+public record TaskQuery(String cursor, int limit, String columnId, TaskStatus status) {
+
+    public TaskQuery {
+        if (limit < 1 || limit > BoardQuery.MAX_LIMIT) {
+            throw new IllegalArgumentException("limit must be between 1 and " + BoardQuery.MAX_LIMIT);
+        }
+    }
+
+    public static TaskQuery all() {
+        return new TaskQuery(null, BoardQuery.DEFAULT_LIMIT, null, null);
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/support/BoardsErrorCode.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/support/BoardsErrorCode.java
@@ -1,0 +1,24 @@
+package com.massimotter.weave.backend.boards.support;
+
+public enum BoardsErrorCode {
+    UNAUTHORIZED("unauthorized"),
+    FORBIDDEN("forbidden"),
+    NOT_FOUND("not_found"),
+    CONFLICT("conflict"),
+    RATE_LIMITED("rate_limited"),
+    OFFLINE("offline"),
+    VALIDATION("validation"),
+    PROVIDER_UNAVAILABLE("provider_unavailable"),
+    UNKNOWN("unknown"),
+    UNSUPPORTED_CAPABILITY("unsupported_capability");
+
+    private final String contractName;
+
+    BoardsErrorCode(String contractName) {
+        this.contractName = contractName;
+    }
+
+    public String contractName() {
+        return contractName;
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/support/BoardsException.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/support/BoardsException.java
@@ -1,0 +1,33 @@
+package com.massimotter.weave.backend.boards.support;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Internal Boards exception that carries only support-safe public details.
+ * Provider stack traces, URLs with tokens, and raw upstream messages must stay out of this type.
+ */
+public class BoardsException extends RuntimeException {
+
+    private final BoardsErrorCode code;
+    private final Map<String, String> details;
+
+    public BoardsException(BoardsErrorCode code, String supportSafeMessage) {
+        this(code, supportSafeMessage, Map.of());
+    }
+
+    public BoardsException(BoardsErrorCode code, String supportSafeMessage, Map<String, String> details) {
+        super(requireNonNull(supportSafeMessage, "supportSafeMessage must not be null"));
+        this.code = requireNonNull(code, "code must not be null");
+        this.details = Map.copyOf(requireNonNull(details, "details must not be null"));
+    }
+
+    public BoardsErrorCode code() {
+        return code;
+    }
+
+    public Map<String, String> details() {
+        return details;
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/vikunja/VikunjaBoardsMapper.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/vikunja/VikunjaBoardsMapper.java
@@ -1,0 +1,116 @@
+package com.massimotter.weave.backend.boards.vikunja;
+
+import com.massimotter.weave.backend.boards.domain.Board;
+import com.massimotter.weave.backend.boards.domain.BoardColumn;
+import com.massimotter.weave.backend.boards.domain.ColumnSemanticStatus;
+import com.massimotter.weave.backend.boards.domain.ProjectVisibility;
+import com.massimotter.weave.backend.boards.domain.ProviderKind;
+import com.massimotter.weave.backend.boards.domain.ProviderRef;
+import com.massimotter.weave.backend.boards.domain.TaskItem;
+import com.massimotter.weave.backend.boards.domain.TaskPriority;
+import com.massimotter.weave.backend.boards.domain.TaskStatus;
+import com.massimotter.weave.backend.boards.domain.WeaveProject;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * First provider adapter boundary for Vikunja. Vikunja words such as "project"
+ * and "bucket" are translated here so the rest of Weave can keep provider-neutral
+ * project, board, column, and task concepts.
+ */
+public final class VikunjaBoardsMapper {
+
+    public WeaveProject toProject(VikunjaProjectSnapshot source) {
+        return new WeaveProject(
+                weaveId("project", source.id()),
+                source.title(),
+                source.archived() ? ProjectVisibility.PRIVATE : ProjectVisibility.WORKSPACE,
+                List.of(),
+                List.of(providerRef("project", source.id(), source.webUrl(), null, null)));
+    }
+
+    public Board toBoard(VikunjaProjectSnapshot source, List<BoardColumn> columns) {
+        return new Board(
+                weaveId("board", source.id()),
+                weaveId("project", source.id()),
+                source.title(),
+                source.description(),
+                columns,
+                source.archived(),
+                List.of(providerRef("project", source.id(), source.webUrl(), null, null)));
+    }
+
+    public BoardColumn toColumn(VikunjaBucketSnapshot source) {
+        return new BoardColumn(
+                weaveId("column", source.id()),
+                weaveId("board", source.projectId()),
+                source.title(),
+                source.position(),
+                semanticStatus(source.title()),
+                source.limit(),
+                List.of(providerRef("bucket", source.id(), null, null, null)));
+    }
+
+    public TaskItem toTask(VikunjaTaskSnapshot source) {
+        Instant updatedAt = source.updatedAt() == null ? Instant.EPOCH : source.updatedAt();
+        return new TaskItem(
+                weaveId("task", source.id()),
+                weaveId("board", source.projectId()),
+                weaveId("column", source.bucketId()),
+                source.title(),
+                source.description(),
+                source.done() ? TaskStatus.COMPLETED : TaskStatus.OPEN,
+                source.position(),
+                source.assigneeRefs(),
+                source.labelRefs(),
+                priority(source.priority()),
+                source.startAt(),
+                source.dueAt(),
+                source.doneAt(),
+                updatedAt,
+                List.of(providerRef("task", source.id(), source.webUrl(), source.etag(), updatedAt)));
+    }
+
+    private ColumnSemanticStatus semanticStatus(String title) {
+        String normalized = title == null ? "" : title.toLowerCase(Locale.ROOT).replace('-', ' ').replace('_', ' ').trim();
+        if (normalized.contains("done") || normalized.contains("complete")) {
+            return ColumnSemanticStatus.DONE;
+        }
+        if (normalized.contains("block")) {
+            return ColumnSemanticStatus.BLOCKED;
+        }
+        if (normalized.contains("doing") || normalized.contains("progress")) {
+            return ColumnSemanticStatus.IN_PROGRESS;
+        }
+        if (normalized.contains("archive")) {
+            return ColumnSemanticStatus.ARCHIVED;
+        }
+        return ColumnSemanticStatus.NOT_STARTED;
+    }
+
+    private TaskPriority priority(Integer priority) {
+        if (priority == null) {
+            return null;
+        }
+        if (priority >= 4) {
+            return TaskPriority.URGENT;
+        }
+        if (priority == 3) {
+            return TaskPriority.HIGH;
+        }
+        if (priority == 1) {
+            return TaskPriority.LOW;
+        }
+        return TaskPriority.NORMAL;
+    }
+
+    private ProviderRef providerRef(String type, long id, java.net.URI url, String etag, Instant lastSyncedAt) {
+        return new ProviderRef(ProviderKind.VIKUNJA, type + ":" + id, url, null, etag, lastSyncedAt);
+    }
+
+    private String weaveId(String type, long id) {
+        return "vikunja:" + type + ":" + id;
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/vikunja/VikunjaBoardsRepository.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/vikunja/VikunjaBoardsRepository.java
@@ -1,0 +1,110 @@
+package com.massimotter.weave.backend.boards.vikunja;
+
+import com.massimotter.weave.backend.boards.domain.Board;
+import com.massimotter.weave.backend.boards.domain.BoardCapability;
+import com.massimotter.weave.backend.boards.domain.BoardColumn;
+import com.massimotter.weave.backend.boards.domain.BoardProviderCapabilities;
+import com.massimotter.weave.backend.boards.domain.Label;
+import com.massimotter.weave.backend.boards.domain.ProviderKind;
+import com.massimotter.weave.backend.boards.domain.TaskAttachment;
+import com.massimotter.weave.backend.boards.domain.TaskComment;
+import com.massimotter.weave.backend.boards.domain.TaskItem;
+import com.massimotter.weave.backend.boards.domain.WeaveProject;
+import com.massimotter.weave.backend.boards.port.BoardPage;
+import com.massimotter.weave.backend.boards.port.BoardQuery;
+import com.massimotter.weave.backend.boards.port.BoardsRepository;
+import com.massimotter.weave.backend.boards.port.CreateTaskCommand;
+import com.massimotter.weave.backend.boards.port.MoveTaskCommand;
+import com.massimotter.weave.backend.boards.port.TaskQuery;
+import com.massimotter.weave.backend.boards.support.BoardsErrorCode;
+import com.massimotter.weave.backend.boards.support.BoardsException;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Non-runtime Vikunja repository boundary. It intentionally fails closed until a
+ * later promotion spec defines authentication, HTTP client behavior, route DTOs,
+ * OpenAPI publication, and smoke/E2E coverage.
+ */
+public final class VikunjaBoardsRepository implements BoardsRepository {
+
+    @Override
+    public BoardProviderCapabilities capabilities() {
+        return new BoardProviderCapabilities(
+                ProviderKind.VIKUNJA,
+                false,
+                EnumSet.of(
+                        BoardCapability.COMMENTS,
+                        BoardCapability.ATTACHMENTS,
+                        BoardCapability.NON_DESTRUCTIVE_ARCHIVE,
+                        BoardCapability.WEBHOOK_EVENTS,
+                        BoardCapability.INCREMENTAL_SYNC,
+                        BoardCapability.CHECKLISTS,
+                        BoardCapability.ACCESSIBLE_NON_DRAG_MOVES),
+                EnumSet.of(BoardCapability.CUSTOM_FIELDS),
+                "Vikunja is the first adapter boundary, but the Boards/Tasks module is hidden and disabled for Release 1.");
+    }
+
+    @Override
+    public BoardPage<WeaveProject> listProjects(BoardQuery query) {
+        throw disabled();
+    }
+
+    @Override
+    public BoardPage<Board> listBoards(String projectId, BoardQuery query) {
+        throw disabled();
+    }
+
+    @Override
+    public Optional<Board> findBoard(String boardId) {
+        throw disabled();
+    }
+
+    @Override
+    public BoardPage<BoardColumn> listColumns(String boardId, BoardQuery query) {
+        throw disabled();
+    }
+
+    @Override
+    public BoardPage<TaskItem> listTasks(String boardId, TaskQuery query) {
+        throw disabled();
+    }
+
+    @Override
+    public BoardPage<Label> listLabels(String boardId, BoardQuery query) {
+        throw disabled();
+    }
+
+    @Override
+    public BoardPage<TaskComment> listComments(String taskId, BoardQuery query) {
+        throw disabled();
+    }
+
+    @Override
+    public BoardPage<TaskAttachment> listAttachments(String taskId, BoardQuery query) {
+        throw disabled();
+    }
+
+    @Override
+    public TaskItem createTask(CreateTaskCommand command) {
+        throw disabled();
+    }
+
+    @Override
+    public TaskItem moveTask(MoveTaskCommand command) {
+        throw disabled();
+    }
+
+    @Override
+    public TaskItem completeTask(String taskId) {
+        throw disabled();
+    }
+
+    private BoardsException disabled() {
+        return new BoardsException(
+                BoardsErrorCode.PROVIDER_UNAVAILABLE,
+                "Vikunja Boards/Tasks adapter is preview-only and disabled until a promotion spec enables backend routes.");
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/vikunja/VikunjaBucketSnapshot.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/vikunja/VikunjaBucketSnapshot.java
@@ -1,0 +1,9 @@
+package com.massimotter.weave.backend.boards.vikunja;
+
+public record VikunjaBucketSnapshot(
+        long id,
+        long projectId,
+        String title,
+        int position,
+        Integer limit) {
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/vikunja/VikunjaProjectSnapshot.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/vikunja/VikunjaProjectSnapshot.java
@@ -1,0 +1,11 @@
+package com.massimotter.weave.backend.boards.vikunja;
+
+import java.net.URI;
+
+public record VikunjaProjectSnapshot(
+        long id,
+        String title,
+        String description,
+        boolean archived,
+        URI webUrl) {
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/vikunja/VikunjaTaskSnapshot.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/vikunja/VikunjaTaskSnapshot.java
@@ -1,0 +1,29 @@
+package com.massimotter.weave.backend.boards.vikunja;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.List;
+
+public record VikunjaTaskSnapshot(
+        long id,
+        long projectId,
+        long bucketId,
+        String title,
+        String description,
+        boolean done,
+        int position,
+        List<String> assigneeRefs,
+        List<String> labelRefs,
+        Integer priority,
+        Instant startAt,
+        Instant dueAt,
+        Instant doneAt,
+        Instant updatedAt,
+        String etag,
+        URI webUrl) {
+
+    public VikunjaTaskSnapshot {
+        assigneeRefs = List.copyOf(assigneeRefs == null ? List.of() : assigneeRefs);
+        labelRefs = List.copyOf(labelRefs == null ? List.of() : labelRefs);
+    }
+}

--- a/src/main/resources/contracts/boards-preview.openapi.yaml
+++ b/src/main/resources/contracts/boards-preview.openapi.yaml
@@ -1,0 +1,140 @@
+openapi: 3.0.3
+info:
+  title: Weave Boards/Tasks Preview Contract
+  version: preview
+  description: >-
+    Preview-only provider-neutral schema components for future Boards/Tasks work.
+    This document intentionally declares no paths: the module is hidden, disabled
+    for Release 1, and not a published product API until a later promotion spec
+    defines routes, auth scopes, status codes, smoke/E2E, and accessibility gates.
+paths: {}
+components:
+  schemas:
+    ProviderRef:
+      type: object
+      required: [provider, externalId]
+      properties:
+        provider:
+          type: string
+          enum: [vikunja, openproject, nextcloud-deck, in-memory, unknown]
+        externalId:
+          type: string
+        externalUrl:
+          type: string
+          format: uri
+        version:
+          type: string
+        etag:
+          type: string
+        lastSyncedAt:
+          type: string
+          format: date-time
+    WeaveProject:
+      type: object
+      required: [id, name, visibility, memberRefs, providerRefs]
+      properties:
+        id: { type: string }
+        name: { type: string }
+        visibility:
+          type: string
+          enum: [private, workspace, public]
+        memberRefs:
+          type: array
+          items: { type: string }
+        providerRefs:
+          type: array
+          items: { $ref: '#/components/schemas/ProviderRef' }
+    Board:
+      type: object
+      required: [id, projectId, name, columns, archived, providerRefs]
+      properties:
+        id: { type: string }
+        projectId: { type: string }
+        name: { type: string }
+        description: { type: string }
+        columns:
+          type: array
+          items: { $ref: '#/components/schemas/BoardColumn' }
+        archived: { type: boolean }
+        providerRefs:
+          type: array
+          items: { $ref: '#/components/schemas/ProviderRef' }
+    BoardColumn:
+      type: object
+      required: [id, boardId, name, position, semanticStatus, providerRefs]
+      properties:
+        id: { type: string }
+        boardId: { type: string }
+        name: { type: string }
+        position: { type: integer, minimum: 0 }
+        semanticStatus:
+          type: string
+          enum: [not_started, in_progress, blocked, done, archived]
+        wipLimit:
+          type: integer
+          minimum: 1
+        providerRefs:
+          type: array
+          items: { $ref: '#/components/schemas/ProviderRef' }
+    TaskItem:
+      type: object
+      required: [id, boardId, columnId, title, status, position, assigneeRefs, labelRefs, updatedAt, providerRefs]
+      properties:
+        id: { type: string }
+        boardId: { type: string }
+        columnId: { type: string }
+        title: { type: string }
+        description: { type: string }
+        status:
+          type: string
+          enum: [open, blocked, completed, archived]
+        position: { type: integer, minimum: 0 }
+        assigneeRefs:
+          type: array
+          items: { type: string }
+        labelRefs:
+          type: array
+          items: { type: string }
+        priority:
+          type: string
+          enum: [low, normal, high, urgent]
+        startAt: { type: string, format: date-time }
+        dueAt: { type: string, format: date-time }
+        completedAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+        providerRefs:
+          type: array
+          items: { $ref: '#/components/schemas/ProviderRef' }
+    TaskBoardEvent:
+      type: object
+      required: [idempotencyKey, type, actorRef, occurredAt, workspaceId, redactionLevel, payload]
+      properties:
+        idempotencyKey: { type: string }
+        type:
+          type: string
+          enum:
+            - task.created
+            - task.updated
+            - task.completed
+            - task.archived
+            - task.moved
+            - assignment.changed
+            - label.changed
+            - priority.changed
+            - due_date.changed
+            - comment.added
+            - attachment.changed
+            - sync.conflict_detected
+        actorRef: { type: string }
+        occurredAt: { type: string, format: date-time }
+        workspaceId: { type: string }
+        projectId: { type: string }
+        boardId: { type: string }
+        taskId: { type: string }
+        providerRef: { $ref: '#/components/schemas/ProviderRef' }
+        redactionLevel:
+          type: string
+          enum: [public_metadata, workspace_internal, support_safe, private_content]
+        payload:
+          type: object
+          additionalProperties: true

--- a/src/main/resources/contracts/task-board-event.schema.json
+++ b/src/main/resources/contracts/task-board-event.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://weave.local/contracts/task-board-event.schema.json",
+  "title": "TaskBoardEvent",
+  "description": "Preview-only normalized Boards/Tasks event envelope. Hidden for Release 1 until a promotion spec defines publication semantics.",
+  "type": "object",
+  "required": [
+    "idempotencyKey",
+    "type",
+    "actorRef",
+    "occurredAt",
+    "workspaceId",
+    "redactionLevel",
+    "payload"
+  ],
+  "properties": {
+    "idempotencyKey": { "type": "string", "minLength": 1 },
+    "type": {
+      "type": "string",
+      "enum": [
+        "task.created",
+        "task.updated",
+        "task.completed",
+        "task.archived",
+        "task.moved",
+        "assignment.changed",
+        "label.changed",
+        "priority.changed",
+        "due_date.changed",
+        "comment.added",
+        "attachment.changed",
+        "sync.conflict_detected"
+      ]
+    },
+    "actorRef": { "type": "string", "minLength": 1 },
+    "occurredAt": { "type": "string", "format": "date-time" },
+    "workspaceId": { "type": "string", "minLength": 1 },
+    "projectId": { "type": "string" },
+    "boardId": { "type": "string" },
+    "taskId": { "type": "string" },
+    "providerRef": {
+      "type": "object",
+      "required": ["provider", "externalId"],
+      "properties": {
+        "provider": {
+          "type": "string",
+          "enum": ["vikunja", "openproject", "nextcloud-deck", "in-memory", "unknown"]
+        },
+        "externalId": { "type": "string", "minLength": 1 },
+        "externalUrl": { "type": "string", "format": "uri" },
+        "version": { "type": "string" },
+        "etag": { "type": "string" },
+        "lastSyncedAt": { "type": "string", "format": "date-time" }
+      },
+      "additionalProperties": false
+    },
+    "redactionLevel": {
+      "type": "string",
+      "enum": ["public_metadata", "workspace_internal", "support_safe", "private_content"]
+    },
+    "payload": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/test/java/com/massimotter/weave/backend/boards/BoardsPreviewContractTest.java
+++ b/src/test/java/com/massimotter/weave/backend/boards/BoardsPreviewContractTest.java
@@ -1,0 +1,124 @@
+package com.massimotter.weave.backend.boards;
+
+import com.massimotter.weave.backend.boards.domain.BoardCapability;
+import com.massimotter.weave.backend.boards.domain.EventRedactionLevel;
+import com.massimotter.weave.backend.boards.domain.ProviderKind;
+import com.massimotter.weave.backend.boards.domain.TaskBoardEvent;
+import com.massimotter.weave.backend.boards.domain.TaskBoardEventType;
+import com.massimotter.weave.backend.boards.port.BoardsPreviewGuard;
+import com.massimotter.weave.backend.boards.port.NoopTaskBoardEventPublisher;
+import com.massimotter.weave.backend.boards.support.BoardsErrorCode;
+import com.massimotter.weave.backend.boards.support.BoardsException;
+import com.massimotter.weave.backend.boards.vikunja.VikunjaBoardsRepository;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class BoardsPreviewContractTest {
+
+    @Test
+    void previewGuardFailsClosedWhenBoardsAreNotEnabled() {
+        var guard = new BoardsPreviewGuard(false);
+
+        assertThat(guard.enabled()).isFalse();
+        assertThatThrownBy(guard::requireEnabled)
+                .isInstanceOf(BoardsException.class)
+                .satisfies(error -> assertThat(((BoardsException) error).code())
+                        .isEqualTo(BoardsErrorCode.PROVIDER_UNAVAILABLE))
+                .hasMessageContaining("hidden preview module")
+                .hasMessageContaining("Release 1");
+    }
+
+    @Test
+    void vikunjaRepositoryAdvertisesBoundaryCapabilitiesButStaysDisabled() {
+        var repository = new VikunjaBoardsRepository();
+
+        var capabilities = repository.capabilities();
+
+        assertThat(capabilities.provider()).isEqualTo(ProviderKind.VIKUNJA);
+        assertThat(capabilities.enabled()).isFalse();
+        assertThat(capabilities.supported()).contains(
+                BoardCapability.COMMENTS,
+                BoardCapability.ATTACHMENTS,
+                BoardCapability.NON_DESTRUCTIVE_ARCHIVE,
+                BoardCapability.WEBHOOK_EVENTS,
+                BoardCapability.INCREMENTAL_SYNC,
+                BoardCapability.CHECKLISTS,
+                BoardCapability.ACCESSIBLE_NON_DRAG_MOVES);
+        assertThat(capabilities.unsupported()).contains(BoardCapability.CUSTOM_FIELDS);
+        assertThatThrownBy(() -> repository.listProjects(null))
+                .isInstanceOf(BoardsException.class)
+                .satisfies(error -> assertThat(((BoardsException) error).code())
+                        .isEqualTo(BoardsErrorCode.PROVIDER_UNAVAILABLE))
+                .hasMessageContaining("preview-only")
+                .hasMessageContaining("disabled");
+    }
+
+    @Test
+    void allSpecEventTypesRemainRepresentedInTheJavaContract() {
+        assertThat(Arrays.stream(TaskBoardEventType.values()).map(TaskBoardEventType::contractName))
+                .containsExactlyInAnyOrder(
+                        "task.created",
+                        "task.updated",
+                        "task.completed",
+                        "task.archived",
+                        "task.moved",
+                        "assignment.changed",
+                        "label.changed",
+                        "priority.changed",
+                        "due_date.changed",
+                        "comment.added",
+                        "attachment.changed",
+                        "sync.conflict_detected");
+    }
+
+    @Test
+    void noopPublisherValidatesEventEnvelopeWithoutEnablingRuntimePublication() {
+        var publisher = new NoopTaskBoardEventPublisher();
+        var event = new TaskBoardEvent(
+                "task-99:moved:2026-05-14T10:00:00Z",
+                TaskBoardEventType.TASK_MOVED,
+                "user:alice",
+                Instant.parse("2026-05-14T10:00:00Z"),
+                "workspace:weave",
+                "project:launch",
+                "board:launch",
+                "task:99",
+                null,
+                EventRedactionLevel.SUPPORT_SAFE,
+                Map.of("fromColumnId", "column:todo", "toColumnId", "column:doing"));
+
+        assertThatCode(() -> publisher.publish(event)).doesNotThrowAnyException();
+        assertThatThrownBy(() -> publisher.publish(null)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void previewOpenApiContractDeclaresNoRoutes() throws Exception {
+        String contract = Files.readString(Path.of("src/main/resources/contracts/boards-preview.openapi.yaml"));
+
+        assertThat(contract).contains("title: Weave Boards/Tasks Preview Contract");
+        assertThat(contract).contains("paths: {}");
+        assertThat(contract).contains("TaskBoardEvent");
+        assertThat(contract).contains("task.moved");
+    }
+
+    @Test
+    void eventJsonSchemaIsPreviewOnlyAndContainsProviderNeutralTypes() throws Exception {
+        String schema = Files.readString(Path.of("src/main/resources/contracts/task-board-event.schema.json"));
+
+        assertThat(schema).contains("Preview-only normalized Boards/Tasks event envelope");
+        assertThat(schema).contains("task.created");
+        assertThat(schema).contains("sync.conflict_detected");
+        assertThat(schema).contains("vikunja");
+        assertThat(schema).contains("openproject");
+        assertThat(schema).contains("nextcloud-deck");
+    }
+}

--- a/src/test/java/com/massimotter/weave/backend/boards/VikunjaBoardsMapperTest.java
+++ b/src/test/java/com/massimotter/weave/backend/boards/VikunjaBoardsMapperTest.java
@@ -1,0 +1,110 @@
+package com.massimotter.weave.backend.boards;
+
+import com.massimotter.weave.backend.boards.domain.ColumnSemanticStatus;
+import com.massimotter.weave.backend.boards.domain.ProjectVisibility;
+import com.massimotter.weave.backend.boards.domain.ProviderKind;
+import com.massimotter.weave.backend.boards.domain.TaskPriority;
+import com.massimotter.weave.backend.boards.domain.TaskStatus;
+import com.massimotter.weave.backend.boards.vikunja.VikunjaBoardsMapper;
+import com.massimotter.weave.backend.boards.vikunja.VikunjaBucketSnapshot;
+import com.massimotter.weave.backend.boards.vikunja.VikunjaProjectSnapshot;
+import com.massimotter.weave.backend.boards.vikunja.VikunjaTaskSnapshot;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VikunjaBoardsMapperTest {
+
+    private final VikunjaBoardsMapper mapper = new VikunjaBoardsMapper();
+
+    @Test
+    void mapsVikunjaProjectIntoProviderNeutralProjectAndBoard() {
+        var source = new VikunjaProjectSnapshot(
+                42,
+                "Launch Plan",
+                "Coordinate Release 1 follow-ups",
+                false,
+                URI.create("https://tasks.weave.local/projects/42"));
+
+        var project = mapper.toProject(source);
+        var board = mapper.toBoard(source, List.of());
+
+        assertThat(project.id()).isEqualTo("vikunja:project:42");
+        assertThat(project.name()).isEqualTo("Launch Plan");
+        assertThat(project.visibility()).isEqualTo(ProjectVisibility.WORKSPACE);
+        assertThat(project.providerRefs()).singleElement().satisfies(ref -> {
+            assertThat(ref.provider()).isEqualTo(ProviderKind.VIKUNJA);
+            assertThat(ref.externalId()).isEqualTo("project:42");
+            assertThat(ref.externalUrl()).hasToString("https://tasks.weave.local/projects/42");
+        });
+
+        assertThat(board.id()).isEqualTo("vikunja:board:42");
+        assertThat(board.projectId()).isEqualTo("vikunja:project:42");
+        assertThat(board.name()).isEqualTo("Launch Plan");
+        assertThat(board.description()).isEqualTo("Coordinate Release 1 follow-ups");
+        assertThat(board.archived()).isFalse();
+    }
+
+    @Test
+    void mapsVikunjaBucketIntoSemanticColumnWithoutLeakingBucketVocabulary() {
+        var blocked = mapper.toColumn(new VikunjaBucketSnapshot(7, 42, "Blocked", 2, 3));
+        var progress = mapper.toColumn(new VikunjaBucketSnapshot(8, 42, "In progress", 1, null));
+
+        assertThat(blocked.id()).isEqualTo("vikunja:column:7");
+        assertThat(blocked.boardId()).isEqualTo("vikunja:board:42");
+        assertThat(blocked.semanticStatus()).isEqualTo(ColumnSemanticStatus.BLOCKED);
+        assertThat(blocked.wipLimit()).isEqualTo(3);
+        assertThat(progress.semanticStatus()).isEqualTo(ColumnSemanticStatus.IN_PROGRESS);
+        assertThat(blocked.providerRefs()).singleElement().satisfies(ref -> {
+            assertThat(ref.provider()).isEqualTo(ProviderKind.VIKUNJA);
+            assertThat(ref.externalId()).isEqualTo("bucket:7");
+        });
+    }
+
+    @Test
+    void mapsVikunjaTaskIntoProviderNeutralTaskAndPreservesProviderMetadata() {
+        Instant updatedAt = Instant.parse("2026-05-14T10:00:00Z");
+        Instant dueAt = Instant.parse("2026-05-20T12:00:00Z");
+        var source = new VikunjaTaskSnapshot(
+                99,
+                42,
+                7,
+                "Write provider contract",
+                "Keep it hidden until promoted",
+                false,
+                4,
+                List.of("user:alice"),
+                List.of("label:spec"),
+                4,
+                null,
+                dueAt,
+                null,
+                updatedAt,
+                "etag-99",
+                URI.create("https://tasks.weave.local/tasks/99"));
+
+        var task = mapper.toTask(source);
+
+        assertThat(task.id()).isEqualTo("vikunja:task:99");
+        assertThat(task.boardId()).isEqualTo("vikunja:board:42");
+        assertThat(task.columnId()).isEqualTo("vikunja:column:7");
+        assertThat(task.title()).isEqualTo("Write provider contract");
+        assertThat(task.status()).isEqualTo(TaskStatus.OPEN);
+        assertThat(task.priority()).isEqualTo(TaskPriority.URGENT);
+        assertThat(task.dueAt()).isEqualTo(dueAt);
+        assertThat(task.updatedAt()).isEqualTo(updatedAt);
+        assertThat(task.assigneeRefs()).containsExactly("user:alice");
+        assertThat(task.labelRefs()).containsExactly("label:spec");
+        assertThat(task.providerRefs()).singleElement().satisfies(ref -> {
+            assertThat(ref.provider()).isEqualTo(ProviderKind.VIKUNJA);
+            assertThat(ref.externalId()).isEqualTo("task:99");
+            assertThat(ref.externalUrl()).hasToString("https://tasks.weave.local/tasks/99");
+            assertThat(ref.etag()).isEqualTo("etag-99");
+            assertThat(ref.lastSyncedAt()).isEqualTo(updatedAt);
+        });
+    }
+}


### PR DESCRIPTION
## Problem
Boards/Tasks needs a backend-owned, provider-neutral slice before any provider runtime or UI can leak into the product model.

## Target behavior
- Keep Boards/Tasks hidden and post-Release-1.
- Add provider-neutral Java domain records, repository ports, support-safe errors, and event envelope types.
- Add preview-only JSON/OpenAPI schema artifacts with `paths: {}` and no Spring controller routes.
- Add the first Vikunja adapter boundary/mapper while keeping the repository fail-closed until a later promotion spec enables routes/runtime.
- Document that screenshots/product docs must not treat Boards/Tasks as a Release 1 enabled surface.

## Spec alignment
References workspace spec `specs/14-boards-tasks-domain-and-provider-adapter-contract.md` and preserves the Release 1 boundary from `specs/13-mvp-decisions-and-roadmap.md`.

## Validation
- `./gradlew test --tests '*boards*'`
- `./gradlew test`
- `git diff --check`
- `./gradlew check`

## Contract impact
No published API routes, no runtime provider dependency, no Release 1 navigation. Preview contract files only.
