### PR TITLE
feat(calendar): expose external client setup contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Release 1 is an early operator-facing slice, not the full Teams/Slack migration 
 - workspace capability and release-readiness snapshots at `/api/workspace/capabilities` and `/api/workspace/release-readiness`
 - Nextcloud-backed Files facade endpoints when a backend-owned actor is configured; otherwise they fail closed
 - Calendar facade endpoints mapped to the backend actor's Nextcloud CalDAV workspace calendar when configured; unsafe private-user calendar templates fail closed
+- secret-free Calendar client setup metadata at `GET /api/calendar/client-setup` for Release 2 profile/download planning; it does not return credentials or generate profiles yet
 - OpenAPI JSON at `/v3/api-docs`
 - Actuator health/info endpoints, Gradle wrapper, Dockerfile, and GitHub Actions CI
 
@@ -46,6 +47,7 @@ Avoid using it to replace standards-based native flows by default:
 - `src/test/java/...`: contract and service tests for auth, profiles, readiness, files, and calendar behavior.
 - `docs/runtime-configuration.md`: complete environment-variable reference and fail-closed adapter behavior.
 - `docs/release-operations.md`: Release 1 API operations guide and minimum operator checks.
+- `docs/calendar-client-setup.md`: Release 2 research and phased plan for Apple `.mobileconfig`, Android DAVx5, desktop CalDAV, and read-only webcal/ICS setup.
 - `docs/architecture-alignment.md`: cross-repo responsibility split for app, backend, and infrastructure.
 - `docs/boards-preview-contract.md`: hidden, post-Release-1 Boards/Tasks provider-neutral contract notes; not a Product screenshots or Release 1 surface.
 - `docs/issues/`: historical alignment issue drafts.

--- a/docs/calendar-client-setup.md
+++ b/docs/calendar-client-setup.md
@@ -1,0 +1,82 @@
+# Calendar client setup and profile download plan
+
+Release 2 should make Calendar a fully integrated Weave feature while still allowing users to connect native calendar clients where platforms support it. The app UI remains backed by the `/api/calendar/**` facade; external client setup is a separate standards bridge, not a direct Flutter-to-CalDAV product shortcut.
+
+## Research findings
+
+### Apple platforms: `.mobileconfig`
+
+Apple supports a Calendar configuration profile payload (`PayloadType = com.apple.caldav.account`) for iOS, iPadOS, macOS, Shared iPad user channel, and visionOS. The payload can carry the CalDAV host, port, SSL flag, principal URL, account description, username, and optionally a password. Apple documents that omitted passwords are entered by the user during install.
+
+Release 2 implications:
+
+- A Weave profile download can produce a `.mobileconfig` for Apple platforms.
+- The profile must be generated per user and should be signed before end-user release to avoid scary installation warnings and tampering concerns.
+- We must not embed the backend service account credential or a permanent user secret in a static profile.
+- Safe credential choices are either:
+  - omit the password and let the user enter a revocable per-client app password; or
+  - generate/use a revocable scoped setup token/app password with clear revocation.
+
+### Android: no universal native CalDAV profile
+
+Android does not provide a universal OS-level CalDAV profile install equivalent. DAVx5 is the practical open CalDAV/CardDAV sync adapter. DAVx5 can be launched with explicit intents or `davx5://`, `caldav(s)://`, and `carddav(s)://` links, and can use the Nextcloud login flow so each client receives its own app password. ICS/webcal subscriptions are a separate one-way path; DAVx5 recommends ICSx5 for HTTP/Webcal `.ics` subscriptions.
+
+Release 2 implications:
+
+- Weave should expose a secret-free DAVx5 setup URL and copyable CalDAV discovery URL.
+- Android two-way sync depends on DAVx5 or another CalDAV sync adapter, not on Android Calendar alone.
+- Webcal/ICS should be positioned as read-only subscription/download, not full calendar integration.
+
+### Desktop: mixed support
+
+Desktop support is fragmented:
+
+- macOS can use the same `.mobileconfig` approach as iOS/iPadOS or manual CalDAV account setup.
+- Thunderbird supports CalDAV calendars and can use the discovery/principal URL.
+- GNOME/KDE calendar stacks can use CalDAV through their account/calendar integrations.
+- Outlook on Windows generally does not support CalDAV natively without an add-in; read-only ICS/webcal can help for subscription-only use cases.
+
+Release 2 implications:
+
+- Provide copyable CalDAV discovery/principal URLs and username for manual setup.
+- Provide a future read-only webcal/ICS feed for clients that cannot do CalDAV, backed by revocable tokens.
+- Do not claim universal two-way native desktop support.
+
+### Nextcloud credential boundary
+
+Nextcloud's Login Flow / Login Flow v2 issues per-client credentials/app passwords and lets users revoke clients. It is a safer fit than reusing the user's primary password or embedding backend credentials. Nextcloud also documents app password conversion and deletion endpoints for clients that already authenticate.
+
+Release 2 implications:
+
+- External clients need a per-client Nextcloud credential or future Weave-scoped token accepted at the CalDAV/subscription boundary.
+- The backend must never expose its service-account CalDAV credential to users or generated profiles.
+- If Weave generates a token itself, it needs revocation, expiry/rotation, audit metadata, and a clear mapping to read/write or read-only scope.
+
+## First backend slice
+
+`GET /api/calendar/client-setup` now exposes authenticated, secret-free setup metadata:
+
+- current calendar scope (`workspace`)
+- current user's external calendar username
+- CalDAV discovery and principal URLs
+- platform option matrix for Apple `.mobileconfig`, Android DAVx5, desktop manual CalDAV, and webcal/ICS subscription
+- explicit credential policy that no password, bearer token, app password, or backend actor credential is returned
+
+This endpoint is intentionally not a profile generator yet. It creates the contract surface the app can show in a Release 2 profile/calendar-settings screen while keeping unsafe paths closed.
+
+## Release 2 implementation sequence
+
+1. **Contract and setup metadata (this PR):** expose `/api/calendar/client-setup` and document the platform/security model.
+2. **Private/user calendar access model:** resolve `weave-backend#52` by choosing service-shared workspace calendar + optional per-user sharing, Nextcloud Login Flow/app passwords, or a Weave token bridge. Keep `{user}` CalDAV templates fail-closed until tested.
+3. **Apple profile generator:** add a signed `.mobileconfig` download endpoint that omits passwords or uses revocable scoped credentials only. Add tests proving no backend actor credential can appear in the profile.
+4. **Android setup handoff:** add app/UI support for DAVx5 setup URI, manual fallback instructions, and read-only subscription copy once tokenized ICS exists.
+5. **Read-only subscription tokens:** implement revocable webcal/ICS feed tokens for clients that cannot do CalDAV; label them one-way.
+6. **Calendar product promotion:** once create/read/update/delete and profile setup are safe, enable Calendar as a Release 2 module in app capability/navigation tests.
+7. **Boards/Tasks promotion:** after the provider-neutral API and Vikunja adapter are tested, enable Boards/Tasks with non-drag accessible movement as a hard release gate.
+
+## References
+
+- Apple Calendar payload settings: `com.apple.caldav.account`, host/port/SSL/principal/username/password behavior.
+- DAVx5 integration docs: explicit/implicit intents, `davx5://` URLs, Nextcloud login flow support.
+- DAVx5 ICS FAQ: webcal/ICS is one-way subscription, not two-way CalDAV sync.
+- Nextcloud Login Flow docs: per-client credentials/app passwords and revocation.

--- a/src/main/java/com/massimotter/weave/backend/controller/CalendarController.java
+++ b/src/main/java/com/massimotter/weave/backend/controller/CalendarController.java
@@ -1,6 +1,7 @@
 package com.massimotter.weave.backend.controller;
 
 import com.massimotter.weave.backend.model.ApiErrorResponse;
+import com.massimotter.weave.backend.model.calendar.CalendarClientSetupResponse;
 import com.massimotter.weave.backend.model.calendar.CalendarEventResponse;
 import com.massimotter.weave.backend.model.calendar.CalendarEventsResponse;
 import com.massimotter.weave.backend.model.calendar.CreateCalendarEventRequest;
@@ -60,6 +61,14 @@ public class CalendarController {
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
             OffsetDateTime to) {
         return calendarFacadeService.list(from, to);
+    }
+
+    @GetMapping("/api/calendar/client-setup")
+    @Operation(summary = "Describe native calendar client setup options")
+    @ApiResponse(responseCode = "200", description = "Secret-free native calendar client setup metadata.",
+            content = @Content(schema = @Schema(implementation = CalendarClientSetupResponse.class)))
+    public CalendarClientSetupResponse clientSetup() {
+        return calendarFacadeService.clientSetup();
     }
 
     @PostMapping("/api/calendar/events")

--- a/src/main/java/com/massimotter/weave/backend/model/calendar/CalendarClientSetupOptionResponse.java
+++ b/src/main/java/com/massimotter/weave/backend/model/calendar/CalendarClientSetupOptionResponse.java
@@ -1,0 +1,20 @@
+package com.massimotter.weave.backend.model.calendar;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "A platform-specific external calendar setup option.")
+public record CalendarClientSetupOptionResponse(
+        @Schema(description = "Stable platform identifier.", example = "apple")
+        String platform,
+        @Schema(description = "Setup mechanism.", example = "mobileconfig")
+        String method,
+        @Schema(description = "Whether this setup method is currently safe for Release 2 use.", example = "false")
+        boolean available,
+        @Schema(description = "Optional action URL for supported external clients. Contains no credential.")
+        String actionUrl,
+        @Schema(description = "Support-safe reason when the option is not available yet.")
+        String unavailableReason,
+        @Schema(description = "Human-readable setup notes for the authenticated user.")
+        List<String> notes) {
+}

--- a/src/main/java/com/massimotter/weave/backend/model/calendar/CalendarClientSetupResponse.java
+++ b/src/main/java/com/massimotter/weave/backend/model/calendar/CalendarClientSetupResponse.java
@@ -1,0 +1,18 @@
+package com.massimotter.weave.backend.model.calendar;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "Secret-free calendar client setup metadata for native and desktop calendar apps.")
+public record CalendarClientSetupResponse(
+        @Schema(description = "Calendar ownership scope exposed by the Weave calendar facade.")
+        CalendarScopeResponse scope,
+        @Schema(description = "Authenticated user's external calendar account identifier.", example = "maria")
+        String username,
+        @Schema(description = "CalDAV/WebDAV discovery URLs that may be shown to the user without credentials.")
+        CalendarExternalEndpointsResponse endpoints,
+        @Schema(description = "Explicit credential policy for external clients.")
+        String credentialPolicy,
+        @Schema(description = "Platform-specific setup options. Options never contain passwords or bearer tokens.")
+        List<CalendarClientSetupOptionResponse> options) {
+}

--- a/src/main/java/com/massimotter/weave/backend/model/calendar/CalendarExternalEndpointsResponse.java
+++ b/src/main/java/com/massimotter/weave/backend/model/calendar/CalendarExternalEndpointsResponse.java
@@ -1,0 +1,14 @@
+package com.massimotter.weave.backend.model.calendar;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Secret-free standards endpoints for external calendar clients.")
+public record CalendarExternalEndpointsResponse(
+        @Schema(description = "Canonical Nextcloud/CalDAV technical base URL.", example = "https://files.weave.local")
+        String serverUrl,
+        @Schema(description = "CalDAV discovery root for DAV clients.", example = "https://files.weave.local/remote.php/dav")
+        String caldavDiscoveryUrl,
+        @Schema(description = "User principal URL template for CalDAV clients. Contains no credential.",
+                example = "https://files.weave.local/remote.php/dav/principals/users/maria/")
+        String principalUrl) {
+}

--- a/src/main/java/com/massimotter/weave/backend/service/CalendarFacadeService.java
+++ b/src/main/java/com/massimotter/weave/backend/service/CalendarFacadeService.java
@@ -1,30 +1,50 @@
 package com.massimotter.weave.backend.service;
 
 import com.massimotter.weave.backend.exception.ApiErrorException;
+import com.massimotter.weave.backend.model.calendar.CalendarClientSetupOptionResponse;
+import com.massimotter.weave.backend.model.calendar.CalendarClientSetupResponse;
+import com.massimotter.weave.backend.model.calendar.CalendarExternalEndpointsResponse;
 import com.massimotter.weave.backend.model.calendar.CalendarEventResponse;
 import com.massimotter.weave.backend.model.calendar.CalendarEventsResponse;
+import com.massimotter.weave.backend.model.calendar.CalendarScopeResponse;
 import com.massimotter.weave.backend.model.calendar.CreateCalendarEventRequest;
 import com.massimotter.weave.backend.model.calendar.UpdateCalendarEventRequest;
 import com.massimotter.weave.backend.service.calendar.CalendarAdapter;
 import com.massimotter.weave.backend.service.calendar.CalendarAdapterException;
 import com.massimotter.weave.backend.service.calendar.CalendarPrincipal;
+import java.net.URI;
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Service
 public class CalendarFacadeService {
 
     private final ObjectProvider<CalendarAdapter> calendarAdapterProvider;
+    private final String nextcloudBaseUrl;
 
     public CalendarFacadeService(ObjectProvider<CalendarAdapter> calendarAdapterProvider) {
+        this(calendarAdapterProvider, "https://files.weave.local");
+    }
+
+    @Autowired
+    public CalendarFacadeService(
+            ObjectProvider<CalendarAdapter> calendarAdapterProvider,
+            @Value("${weave.platform.nextcloud-base-url:https://files.weave.local}") String nextcloudBaseUrl) {
         this.calendarAdapterProvider = calendarAdapterProvider;
+        this.nextcloudBaseUrl = nextcloudBaseUrl == null || nextcloudBaseUrl.isBlank()
+                ? "https://files.weave.local"
+                : nextcloudBaseUrl.trim();
     }
 
     public CalendarEventsResponse list(OffsetDateTime from, OffsetDateTime to) {
@@ -58,6 +78,62 @@ public class CalendarFacadeService {
         } catch (CalendarAdapterException exception) {
             throw apiError(exception, "delete-event");
         }
+    }
+
+    public CalendarClientSetupResponse clientSetup() {
+        CalendarPrincipal principal = principal();
+        String username = principal.nextcloudUserId();
+        String discoveryUrl = davUrl("remote.php", "dav");
+        String principalUrl = davUrl("remote.php", "dav", "principals", "users", username) + "/";
+        String davx5Url = davx5Url();
+
+        return new CalendarClientSetupResponse(
+                CalendarScopeResponse.workspace(),
+                username,
+                new CalendarExternalEndpointsResponse(nextcloudBaseUrl, discoveryUrl, principalUrl),
+                "The backend never returns Nextcloud passwords, app passwords, bearer tokens, or static profile secrets. "
+                        + "External clients must use a revocable per-client app password/login flow now, or a future "
+                        + "Weave-issued scoped setup token once implemented.",
+                List.of(
+                        new CalendarClientSetupOptionResponse(
+                                "apple",
+                                "mobileconfig",
+                                false,
+                                null,
+                                "Signed .mobileconfig generation and revocable per-client credentials are not implemented yet.",
+                                List.of(
+                                        "iOS, iPadOS, and macOS can install a CalDAV configuration profile with host, port, SSL, principal URL, and username.",
+                                        "Release 2 must not embed a permanent password or backend service credential in the profile.",
+                                        "The safe target is a signed profile that omits the password or uses a revocable scoped token.")),
+                        new CalendarClientSetupOptionResponse(
+                                "android",
+                                "davx5",
+                                true,
+                                davx5Url,
+                                null,
+                                List.of(
+                                        "Android has no universal native CalDAV account profile equivalent.",
+                                        "DAVx5 can open a secret-free davx5:// setup URL and can use the Nextcloud login flow for per-client credentials.",
+                                        "Webcal/ICS subscriptions are read-only and should remain a separate fallback.")),
+                        new CalendarClientSetupOptionResponse(
+                                "desktop",
+                                "caldav-manual",
+                                true,
+                                discoveryUrl,
+                                null,
+                                List.of(
+                                        "Use the CalDAV discovery or principal URL in clients such as Thunderbird, Apple Calendar, GNOME, or KDE calendar apps.",
+                                        "Microsoft Outlook generally needs an add-in for CalDAV; read-only ICS/webcal can be offered later where acceptable.",
+                                        "Use username " + username + " with a revocable per-client app password/login-flow credential.")),
+                        new CalendarClientSetupOptionResponse(
+                                "subscription",
+                                "webcal-ics",
+                                false,
+                                null,
+                                "A revocable read-only ICS/webcal feed token is not implemented yet.",
+                                List.of(
+                                        "ICS/webcal is one-way subscription/download, not full two-way CalDAV sync.",
+                                        "It is useful for clients without CalDAV support once scoped feed tokens and revocation are available."))));
     }
 
     private CalendarAdapter adapter(String operation) {
@@ -151,5 +227,20 @@ public class CalendarFacadeService {
             return preferred;
         }
         return fallback;
+    }
+
+    private String davUrl(String... pathSegments) {
+        return UriComponentsBuilder.fromUriString(nextcloudBaseUrl)
+                .pathSegment(pathSegments)
+                .build()
+                .toUriString();
+    }
+
+    private String davx5Url() {
+        URI uri = URI.create(nextcloudBaseUrl);
+        String host = uri.getHost() == null ? "files.weave.local" : uri.getHost();
+        int port = uri.getPort();
+        String authority = port > 0 ? host + ":" + port : host;
+        return "davx5://" + authority + "/remote.php/dav";
     }
 }

--- a/src/test/java/com/massimotter/weave/backend/controller/FilesCalendarFacadeControllerTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/FilesCalendarFacadeControllerTest.java
@@ -90,6 +90,31 @@ class FilesCalendarFacadeControllerTest {
     }
 
     @Test
+    void calendarClientSetupExposesSecretFreePlatformOptionsWithoutAdapterCredentials() throws Exception {
+        mockMvc.perform(get("/api/calendar/client-setup")
+                        .with(workspaceJwt()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.scope.type").value("workspace"))
+                .andExpect(jsonPath("$.scope.label").value("Weave workspace calendar"))
+                .andExpect(jsonPath("$.username").value("user-123"))
+                .andExpect(jsonPath("$.endpoints.serverUrl").value("https://files.weave.local"))
+                .andExpect(jsonPath("$.endpoints.caldavDiscoveryUrl")
+                        .value("https://files.weave.local/remote.php/dav"))
+                .andExpect(jsonPath("$.endpoints.principalUrl")
+                        .value("https://files.weave.local/remote.php/dav/principals/users/user-123/"))
+                .andExpect(jsonPath("$.options[0].platform").value("apple"))
+                .andExpect(jsonPath("$.options[0].method").value("mobileconfig"))
+                .andExpect(jsonPath("$.options[0].available").value(false))
+                .andExpect(jsonPath("$.options[1].platform").value("android"))
+                .andExpect(jsonPath("$.options[1].method").value("davx5"))
+                .andExpect(jsonPath("$.options[1].available").value(true))
+                .andExpect(jsonPath("$.options[1].actionUrl")
+                        .value("davx5://files.weave.local/remote.php/dav"))
+                .andExpect(jsonPath("$.options[3].platform").value("subscription"))
+                .andExpect(jsonPath("$.options[3].available").value(false));
+    }
+
+    @Test
     void facadeRequestsUseStableValidationEnvelope() throws Exception {
         String invalidEvent = """
                 {

--- a/src/test/java/com/massimotter/weave/backend/controller/OpenApiDocumentationTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/OpenApiDocumentationTest.java
@@ -47,6 +47,7 @@ class OpenApiDocumentationTest {
                 .andExpect(jsonPath("$.paths['/api/files/{id}/download']").exists())
                 .andExpect(jsonPath("$.paths['/api/files/{id}']").exists())
                 .andExpect(jsonPath("$.paths['/api/calendar/events']").exists())
+                .andExpect(jsonPath("$.paths['/api/calendar/client-setup']").exists())
                 .andExpect(jsonPath("$.paths['/api/calendar/events/{id}']").exists())
                 .andExpect(jsonPath("$.paths['/api/workspace/capabilities']").exists())
                 .andExpect(jsonPath("$.paths['/api/workspace/release-readiness']").exists())


### PR DESCRIPTION
## Summary

- adds authenticated `GET /api/calendar/client-setup` as the first safe Release 2 external-calendar setup contract
- returns secret-free CalDAV discovery/principal URLs, current workspace scope, and platform option status for Apple `.mobileconfig`, Android DAVx5, desktop CalDAV, and future webcal/ICS
- documents the multi-platform research/plan and explicitly keeps generated profiles/tokens disabled until revocable credential handling exists

## Contract / security notes

- App Calendar UI still uses the backend `/api/calendar/**` facade; this endpoint is only metadata for external native client setup.
- The endpoint does **not** return Nextcloud passwords, app passwords, bearer tokens, or backend actor credentials.
- Apple `.mobileconfig` and webcal/ICS are marked unavailable until signed profile generation and/or revocable scoped tokens are implemented.
- Android DAVx5 and desktop manual CalDAV are exposed as secret-free setup paths.

Refs: masssi164/weave-backend#52, workspace specs `06`, `07`, `13`, `14`.

## Validation

- `./gradlew --no-daemon test` ✅
