### PR TITLE
feat(boards): map Vikunja errors safely

### DIFF
--- a/docs/boards-preview-contract.md
+++ b/docs/boards-preview-contract.md
@@ -11,6 +11,7 @@ Implemented now:
 - Provider-neutral Java domain records for projects, boards, columns, tasks, labels, comments, attachments, provider refs, capabilities, and normalized events.
 - A repository port that hides provider pagination, IDs, vocabulary, and raw errors from callers.
 - A support-safe error vocabulary aligned with the workspace spec.
+- A Vikunja HTTP/status error mapper that converts provider failures into Weave codes without leaking raw provider messages, URLs, or tokens.
 - A no-op event publisher boundary plus preview JSON/OpenAPI schema artifacts under `src/main/resources/contracts/`.
 - A first Vikunja adapter boundary and mapper that translates Vikunja projects/buckets/tasks into Weave concepts.
 - A fail-closed Vikunja repository placeholder that advertises preview capabilities but does not perform runtime HTTP calls.
@@ -41,7 +42,7 @@ Vikunja is the first strategic adapter boundary because it is lightweight, self-
 - Vikunja bucket → Weave board column
 - Vikunja task → Weave task item
 
-The repository placeholder fails closed with `provider_unavailable` until a promotion spec defines authentication, HTTP client behavior, persistence/sync expectations, route DTOs, and validation gates.
+The repository placeholder fails closed with `provider_unavailable` until a promotion spec defines authentication, HTTP client behavior, persistence/sync expectations, route DTOs, and validation gates. The adapter boundary now also contains the support-safe HTTP/status mapping expected once real Vikunja calls are introduced: unauthorized, forbidden, not found, conflict, validation, rate limit, offline, provider unavailable, and unknown failures are normalized before reaching product/API code.
 
 ## Contract artifacts
 

--- a/src/main/java/com/massimotter/weave/backend/boards/vikunja/VikunjaErrorMapper.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/vikunja/VikunjaErrorMapper.java
@@ -1,0 +1,68 @@
+package com.massimotter.weave.backend.boards.vikunja;
+
+import com.massimotter.weave.backend.boards.support.BoardsErrorCode;
+import com.massimotter.weave.backend.boards.support.BoardsException;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Support-safe Vikunja error mapper. It keeps raw provider messages, URLs, and
+ * tokens out of the Weave Boards/Tasks boundary while preserving enough context
+ * for diagnostics and future API error envelopes.
+ */
+public final class VikunjaErrorMapper {
+
+    public BoardsException toBoardsException(int httpStatus, String operation) {
+        String safeOperation = requireText(operation, "operation");
+        BoardsErrorCode code = codeFor(httpStatus);
+        Map<String, String> details = new LinkedHashMap<>();
+        details.put("provider", "vikunja");
+        details.put("operation", safeOperation);
+        if (httpStatus > 0) {
+            details.put("httpStatus", Integer.toString(httpStatus));
+        }
+        return new BoardsException(code, messageFor(code), details);
+    }
+
+    private BoardsErrorCode codeFor(int httpStatus) {
+        return switch (httpStatus) {
+            case 0 -> BoardsErrorCode.OFFLINE;
+            case 401 -> BoardsErrorCode.UNAUTHORIZED;
+            case 403 -> BoardsErrorCode.FORBIDDEN;
+            case 404 -> BoardsErrorCode.NOT_FOUND;
+            case 409 -> BoardsErrorCode.CONFLICT;
+            case 422 -> BoardsErrorCode.VALIDATION;
+            case 429 -> BoardsErrorCode.RATE_LIMITED;
+            case 502, 503, 504 -> BoardsErrorCode.PROVIDER_UNAVAILABLE;
+            default -> httpStatus >= 500
+                    ? BoardsErrorCode.PROVIDER_UNAVAILABLE
+                    : BoardsErrorCode.UNKNOWN;
+        };
+    }
+
+    private String messageFor(BoardsErrorCode code) {
+        return switch (code) {
+            case UNAUTHORIZED -> "Vikunja rejected the configured Boards/Tasks credentials.";
+            case FORBIDDEN -> "Vikunja denied access to this Boards/Tasks resource.";
+            case NOT_FOUND -> "The requested Boards/Tasks resource was not found in Vikunja.";
+            case CONFLICT -> "The Boards/Tasks resource changed in Vikunja. Refresh and try again.";
+            case RATE_LIMITED -> "Vikunja rate-limited the Boards/Tasks request. Try again later.";
+            case OFFLINE -> "Vikunja could not be reached for this Boards/Tasks request.";
+            case VALIDATION -> "Vikunja rejected the Boards/Tasks request as invalid.";
+            case PROVIDER_UNAVAILABLE -> "Vikunja is currently unavailable for Boards/Tasks.";
+            case UNKNOWN -> "Vikunja returned an unexpected Boards/Tasks error.";
+            case UNSUPPORTED_CAPABILITY -> "The selected Boards/Tasks capability is not supported by Vikunja.";
+        };
+    }
+
+    private String requireText(String value, String name) {
+        requireNonNull(value, name + " must not be null");
+        if (value.isBlank()) {
+            throw new IllegalArgumentException(name + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/src/test/java/com/massimotter/weave/backend/boards/BoardsPreviewContractTest.java
+++ b/src/test/java/com/massimotter/weave/backend/boards/BoardsPreviewContractTest.java
@@ -10,6 +10,7 @@ import com.massimotter.weave.backend.boards.port.NoopTaskBoardEventPublisher;
 import com.massimotter.weave.backend.boards.support.BoardsErrorCode;
 import com.massimotter.weave.backend.boards.support.BoardsException;
 import com.massimotter.weave.backend.boards.vikunja.VikunjaBoardsRepository;
+import com.massimotter.weave.backend.boards.vikunja.VikunjaErrorMapper;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
@@ -60,6 +61,32 @@ class BoardsPreviewContractTest {
                         .isEqualTo(BoardsErrorCode.PROVIDER_UNAVAILABLE))
                 .hasMessageContaining("preview-only")
                 .hasMessageContaining("disabled");
+    }
+
+    @Test
+    void vikunjaErrorsMapToSupportSafeWeaveCodes() {
+        var mapper = new VikunjaErrorMapper();
+
+        assertThat(mapper.toBoardsException(401, "list-projects").code()).isEqualTo(BoardsErrorCode.UNAUTHORIZED);
+        assertThat(mapper.toBoardsException(403, "list-projects").code()).isEqualTo(BoardsErrorCode.FORBIDDEN);
+        assertThat(mapper.toBoardsException(404, "find-task").code()).isEqualTo(BoardsErrorCode.NOT_FOUND);
+        assertThat(mapper.toBoardsException(409, "move-task").code()).isEqualTo(BoardsErrorCode.CONFLICT);
+        assertThat(mapper.toBoardsException(422, "create-task").code()).isEqualTo(BoardsErrorCode.VALIDATION);
+        assertThat(mapper.toBoardsException(429, "sync").code()).isEqualTo(BoardsErrorCode.RATE_LIMITED);
+        assertThat(mapper.toBoardsException(0, "sync").code()).isEqualTo(BoardsErrorCode.OFFLINE);
+        assertThat(mapper.toBoardsException(503, "sync").code()).isEqualTo(BoardsErrorCode.PROVIDER_UNAVAILABLE);
+        assertThat(mapper.toBoardsException(418, "sync").code()).isEqualTo(BoardsErrorCode.UNKNOWN);
+    }
+
+    @Test
+    void vikunjaErrorDetailsDoNotLeakRawProviderMessages() {
+        var error = new VikunjaErrorMapper().toBoardsException(429, "sync");
+
+        assertThat(error.getMessage()).contains("rate-limited");
+        assertThat(error.details()).containsEntry("provider", "vikunja");
+        assertThat(error.details()).containsEntry("operation", "sync");
+        assertThat(error.details()).containsEntry("httpStatus", "429");
+        assertThat(error.details()).doesNotContainKeys("rawMessage", "url", "token");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds a support-safe Vikunja error mapper for the provider-neutral Boards/Tasks adapter boundary. This keeps the module disabled while preparing the real Vikunja integration path with normalized Weave error codes.

## Changes

- maps Vikunja HTTP/offline failures to the support-safe Boards error vocabulary
- preserves diagnostic provider/operation/status details without raw provider messages, URLs, or tokens
- updates preview contract docs and tests

## Spec / issues

- Follows `specs/14-boards-tasks-domain-and-provider-adapter-contract.md`
- Advances masssi164/weave#119; no runtime routes or provider dependency enabled

## Validation

- `./gradlew test --tests 'com.massimotter.weave.backend.boards.BoardsPreviewContractTest' --tests 'com.massimotter.weave.backend.boards.VikunjaBoardsMapperTest'`\n- `./gradlew test`\n