### PR TITLE
Release 2 Calendar: fail-closed Apple profile scaffold

### DIFF
--- a/docs/calendar-client-setup.md
+++ b/docs/calendar-client-setup.md
@@ -66,12 +66,18 @@ Release 2 implications:
 
 This endpoint is intentionally not a profile generator yet. It creates the contract surface the app can show in a Release 2 profile/calendar-settings screen while keeping unsafe paths closed.
 
+## Backend profile endpoint scaffold
+
+`GET /api/calendar/client-setup/apple.mobileconfig` is now reserved for Apple profile downloads. It is authenticated through the same `weave:workspace` API boundary, but it intentionally returns `503 calendar-apple-profile-unavailable` until real profile signing is wired. The backend keeps an unsigned, no-secret profile renderer under test so the eventual signer has a stable input artifact, but unsigned profiles are not downloadable from the API.
+
+The renderer includes only CalDAV host, port, SSL, principal URL, display label, username, and profile metadata. It deliberately omits `CalDAVPassword` and never reads backend actor credentials, bearer tokens, or static setup secrets. Password-bearing profiles remain blocked until a revocable per-client credential issuance and revocation model exists.
+
 ## Release 2 implementation sequence
 
 1. **Contract and setup metadata (this PR):** expose `/api/calendar/client-setup` and document the platform/security model.
 2. **Access/credential readiness contract:** expose explicit access-model and credential-readiness fields so clients can show honest blocked states before any profile/feed download path exists. Keep `{user}` CalDAV templates fail-closed until tested.
 3. **Private/user calendar access model:** resolve `weave-backend#52` by choosing service-shared workspace calendar + optional per-user sharing, Nextcloud Login Flow/app passwords, or a Weave token bridge.
-4. **Apple profile generator:** add a signed `.mobileconfig` download endpoint that omits passwords or uses revocable scoped credentials only. Add tests proving no backend actor credential can appear in the profile.
+4. **Apple profile generator:** keep the authenticated `.mobileconfig` endpoint fail-closed until profile signing is configured; then serve the tested no-secret profile through a signer, or include only a revocable scoped credential once issuance/revocation exists. Add tests proving no backend actor credential can appear in the profile.
 5. **Android setup handoff:** add app/UI support for DAVx5 setup URI, manual fallback instructions, and read-only subscription copy once tokenized ICS exists.
 6. **Read-only subscription tokens:** implement revocable webcal/ICS feed tokens for clients that cannot do CalDAV; label them one-way.
 7. **Calendar product promotion:** once create/read/update/delete and profile setup are safe, enable Calendar as a Release 2 module in app capability/navigation tests.

--- a/src/main/java/com/massimotter/weave/backend/controller/CalendarController.java
+++ b/src/main/java/com/massimotter/weave/backend/controller/CalendarController.java
@@ -7,6 +7,7 @@ import com.massimotter.weave.backend.model.calendar.CalendarEventsResponse;
 import com.massimotter.weave.backend.model.calendar.CreateCalendarEventRequest;
 import com.massimotter.weave.backend.model.calendar.UpdateCalendarEventRequest;
 import com.massimotter.weave.backend.service.CalendarFacadeService;
+import com.massimotter.weave.backend.service.calendar.AppleMobileConfigProfile;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -18,6 +19,8 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Size;
 import java.time.OffsetDateTime;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -69,6 +72,23 @@ public class CalendarController {
             content = @Content(schema = @Schema(implementation = CalendarClientSetupResponse.class)))
     public CalendarClientSetupResponse clientSetup() {
         return calendarFacadeService.clientSetup();
+    }
+
+
+    @GetMapping(
+            value = "/api/calendar/client-setup/apple.mobileconfig",
+            produces = "application/x-apple-aspen-config")
+    @Operation(summary = "Download a signed Apple Calendar setup profile")
+    @ApiResponse(responseCode = "200", description = "Signed secret-free Apple Calendar .mobileconfig profile.",
+            content = @Content(mediaType = "application/x-apple-aspen-config"))
+    @ApiResponse(responseCode = "503", description = "Profile signing or revocable credential support is not configured yet.",
+            content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+    public ResponseEntity<byte[]> appleMobileConfigProfile() {
+        AppleMobileConfigProfile profile = calendarFacadeService.appleMobileConfigProfile();
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType("application/x-apple-aspen-config"))
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + profile.filename() + "\"")
+                .body(profile.content());
     }
 
     @PostMapping("/api/calendar/events")

--- a/src/main/java/com/massimotter/weave/backend/service/CalendarFacadeService.java
+++ b/src/main/java/com/massimotter/weave/backend/service/CalendarFacadeService.java
@@ -13,6 +13,8 @@ import com.massimotter.weave.backend.model.calendar.CreateCalendarEventRequest;
 import com.massimotter.weave.backend.model.calendar.UpdateCalendarEventRequest;
 import com.massimotter.weave.backend.service.calendar.CalendarAdapter;
 import com.massimotter.weave.backend.service.calendar.CalendarAdapterException;
+import com.massimotter.weave.backend.service.calendar.AppleMobileConfigProfile;
+import com.massimotter.weave.backend.service.calendar.AppleMobileConfigProfileRenderer;
 import com.massimotter.weave.backend.service.calendar.CalendarPrincipal;
 import java.net.URI;
 import java.time.OffsetDateTime;
@@ -34,6 +36,7 @@ public class CalendarFacadeService {
 
     private final ObjectProvider<CalendarAdapter> calendarAdapterProvider;
     private final String nextcloudBaseUrl;
+    private final AppleMobileConfigProfileRenderer appleProfileRenderer;
 
     public CalendarFacadeService(ObjectProvider<CalendarAdapter> calendarAdapterProvider) {
         this(calendarAdapterProvider, "https://files.weave.local");
@@ -47,6 +50,7 @@ public class CalendarFacadeService {
         this.nextcloudBaseUrl = nextcloudBaseUrl == null || nextcloudBaseUrl.isBlank()
                 ? "https://files.weave.local"
                 : nextcloudBaseUrl.trim();
+        this.appleProfileRenderer = new AppleMobileConfigProfileRenderer(this.nextcloudBaseUrl);
     }
 
     public CalendarEventsResponse list(OffsetDateTime from, OffsetDateTime to) {
@@ -104,11 +108,11 @@ public class CalendarFacadeService {
                                 "mobileconfig",
                                 false,
                                 null,
-                                "Signed .mobileconfig generation and revocable per-client credentials are not implemented yet.",
+                                "Signed .mobileconfig download remains fail-closed until profile signing and revocable credentials are implemented.",
                                 List.of(
                                         "iOS, iPadOS, and macOS can install a CalDAV configuration profile with host, port, SSL, principal URL, and username.",
                                         "Release 2 must not embed a permanent password or backend service credential in the profile.",
-                                        "The safe target is a signed profile that omits the password or uses a revocable scoped token.")),
+                                        "The backend route is reserved for a signed no-secret profile and currently returns 503 rather than serving an unsigned artifact.")),
                         new CalendarClientSetupOptionResponse(
                                 "android",
                                 "davx5",
@@ -138,6 +142,27 @@ public class CalendarFacadeService {
                                 List.of(
                                         "ICS/webcal is one-way subscription/download, not full two-way CalDAV sync.",
                                         "It is useful for clients without CalDAV support once scoped feed tokens and revocation are available."))));
+    }
+
+
+    public AppleMobileConfigProfile appleMobileConfigProfile() {
+        // Keep the download route present but unavailable until a real signing path is wired.
+        // The unsigned renderer is covered by tests so the future signer has a no-secret input artifact.
+        appleProfileRenderer.renderUnsignedNoSecretProfile(principal());
+        throw new ApiErrorException(
+                HttpStatus.SERVICE_UNAVAILABLE,
+                "calendar-apple-profile-unavailable",
+                "Apple Calendar profile download is not available until signed no-secret profile generation is configured.",
+                Map.of(
+                        "module", "calendar",
+                        "operation", "download-apple-mobileconfig",
+                        "requiresSignedProfile", true,
+                        "passwordIncluded", false,
+                        "backendActorCredentialsExposed", false,
+                        "blockers", List.of(
+                                "Profile signing is not configured or implemented in this backend slice.",
+                                "Revocable per-client CalDAV credential issuance remains a prerequisite for password-bearing profiles.",
+                                "Unsigned profiles are deliberately not downloadable from the authenticated API.")));
     }
 
     private CalendarAccessModelResponse accessModel() {

--- a/src/main/java/com/massimotter/weave/backend/service/calendar/AppleMobileConfigProfile.java
+++ b/src/main/java/com/massimotter/weave/backend/service/calendar/AppleMobileConfigProfile.java
@@ -1,0 +1,4 @@
+package com.massimotter.weave.backend.service.calendar;
+
+public record AppleMobileConfigProfile(String filename, byte[] content) {
+}

--- a/src/main/java/com/massimotter/weave/backend/service/calendar/AppleMobileConfigProfileRenderer.java
+++ b/src/main/java/com/massimotter/weave/backend/service/calendar/AppleMobileConfigProfileRenderer.java
@@ -1,0 +1,126 @@
+package com.massimotter.weave.backend.service.calendar;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+public class AppleMobileConfigProfileRenderer {
+
+    private final String nextcloudBaseUrl;
+
+    public AppleMobileConfigProfileRenderer(String nextcloudBaseUrl) {
+        this.nextcloudBaseUrl = nextcloudBaseUrl == null || nextcloudBaseUrl.isBlank()
+                ? "https://files.weave.local"
+                : nextcloudBaseUrl.trim();
+    }
+
+    public AppleMobileConfigProfile renderUnsignedNoSecretProfile(CalendarPrincipal principal) {
+        URI baseUri = URI.create(nextcloudBaseUrl);
+        String host = firstNonBlank(baseUri.getHost(), "files.weave.local");
+        boolean ssl = !"http".equalsIgnoreCase(firstNonBlank(baseUri.getScheme(), "https"));
+        int port = baseUri.getPort() > 0 ? baseUri.getPort() : (ssl ? 443 : 80);
+        String username = firstNonBlank(principal.nextcloudUserId(), principal.subject());
+        String principalPath = "/remote.php/dav/principals/users/" + pathSegment(username) + "/";
+        String safeUsername = sanitizeFilename(username);
+
+        String profileUuid = stableUuid("weave-calendar-profile:" + principal.subject());
+        String payloadUuid = stableUuid("weave-calendar-caldav:" + principal.subject() + ":" + username);
+
+        String plist = """
+                <?xml version=\"1.0\" encoding=\"UTF-8\"?>
+                <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+                <plist version=\"1.0\">
+                <dict>
+                    <key>PayloadContent</key>
+                    <array>
+                        <dict>
+                            <key>PayloadType</key>
+                            <string>com.apple.caldav.account</string>
+                            <key>PayloadVersion</key>
+                            <integer>1</integer>
+                            <key>PayloadIdentifier</key>
+                            <string>local.weave.calendar.caldav.%s</string>
+                            <key>PayloadUUID</key>
+                            <string>%s</string>
+                            <key>PayloadDisplayName</key>
+                            <string>Weave Calendar</string>
+                            <key>PayloadDescription</key>
+                            <string>Secret-free CalDAV account metadata. The password is intentionally omitted; use a revocable per-client Nextcloud app password or login-flow credential.</string>
+                            <key>CalDAVAccountDescription</key>
+                            <string>Weave workspace calendar</string>
+                            <key>CalDAVHostName</key>
+                            <string>%s</string>
+                            <key>CalDAVPort</key>
+                            <integer>%d</integer>
+                            <key>CalDAVUseSSL</key>
+                            <%s/>
+                            <key>CalDAVPrincipalURL</key>
+                            <string>%s</string>
+                            <key>CalDAVUsername</key>
+                            <string>%s</string>
+                        </dict>
+                    </array>
+                    <key>PayloadType</key>
+                    <string>Configuration</string>
+                    <key>PayloadVersion</key>
+                    <integer>1</integer>
+                    <key>PayloadIdentifier</key>
+                    <string>local.weave.calendar.%s</string>
+                    <key>PayloadUUID</key>
+                    <string>%s</string>
+                    <key>PayloadDisplayName</key>
+                    <string>Weave Calendar</string>
+                    <key>PayloadDescription</key>
+                    <string>Weave Calendar CalDAV setup profile. Contains no password, bearer token, backend actor credential, or other static secret.</string>
+                    <key>PayloadOrganization</key>
+                    <string>Weave</string>
+                    <key>PayloadRemovalDisallowed</key>
+                    <false/>
+                </dict>
+                </plist>
+                """.formatted(
+                xml(safeUsername),
+                payloadUuid,
+                xml(host),
+                port,
+                ssl ? "true" : "false",
+                xml(principalPath),
+                xml(username),
+                xml(safeUsername),
+                profileUuid);
+
+        return new AppleMobileConfigProfile(
+                "weave-calendar-" + safeUsername + ".mobileconfig",
+                plist.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private String stableUuid(String value) {
+        return UUID.nameUUIDFromBytes(value.getBytes(StandardCharsets.UTF_8)).toString();
+    }
+
+    private String firstNonBlank(String preferred, String fallback) {
+        if (preferred != null && !preferred.isBlank()) {
+            return preferred;
+        }
+        return fallback;
+    }
+
+    private String pathSegment(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
+    }
+
+    private String sanitizeFilename(String value) {
+        String sanitized = value == null ? "user" : value.replaceAll("[^A-Za-z0-9._-]", "-");
+        return sanitized.isBlank() ? "user" : sanitized;
+    }
+
+    private String xml(String value) {
+        return value
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&apos;");
+    }
+}

--- a/src/test/java/com/massimotter/weave/backend/controller/FilesCalendarFacadeControllerTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/FilesCalendarFacadeControllerTest.java
@@ -123,6 +123,27 @@ class FilesCalendarFacadeControllerTest {
                 .andExpect(jsonPath("$.options[3].available").value(false));
     }
 
+
+    @Test
+    void calendarAppleProfileRequiresAuthenticatedWorkspaceScope() throws Exception {
+        mockMvc.perform(get("/api/calendar/client-setup/apple.mobileconfig"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("unauthorized"));
+    }
+
+    @Test
+    void calendarAppleProfileDownloadStaysFailClosedUntilSigningExists() throws Exception {
+        mockMvc.perform(get("/api/calendar/client-setup/apple.mobileconfig")
+                        .with(workspaceJwt()))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(header().exists("X-Request-Id"))
+                .andExpect(jsonPath("$.code").value("calendar-apple-profile-unavailable"))
+                .andExpect(jsonPath("$.details.operation").value("download-apple-mobileconfig"))
+                .andExpect(jsonPath("$.details.requiresSignedProfile").value(true))
+                .andExpect(jsonPath("$.details.passwordIncluded").value(false))
+                .andExpect(jsonPath("$.details.backendActorCredentialsExposed").value(false));
+    }
+
     @Test
     void facadeRequestsUseStableValidationEnvelope() throws Exception {
         String invalidEvent = """

--- a/src/test/java/com/massimotter/weave/backend/controller/OpenApiDocumentationTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/OpenApiDocumentationTest.java
@@ -48,6 +48,7 @@ class OpenApiDocumentationTest {
                 .andExpect(jsonPath("$.paths['/api/files/{id}']").exists())
                 .andExpect(jsonPath("$.paths['/api/calendar/events']").exists())
                 .andExpect(jsonPath("$.paths['/api/calendar/client-setup']").exists())
+                .andExpect(jsonPath("$.paths['/api/calendar/client-setup/apple.mobileconfig']").exists())
                 .andExpect(jsonPath("$.paths['/api/calendar/events/{id}']").exists())
                 .andExpect(jsonPath("$.paths['/api/workspace/capabilities']").exists())
                 .andExpect(jsonPath("$.paths['/api/workspace/release-readiness']").exists())

--- a/src/test/java/com/massimotter/weave/backend/service/calendar/AppleMobileConfigProfileRendererTest.java
+++ b/src/test/java/com/massimotter/weave/backend/service/calendar/AppleMobileConfigProfileRendererTest.java
@@ -1,0 +1,51 @@
+package com.massimotter.weave.backend.service.calendar;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AppleMobileConfigProfileRendererTest {
+
+    @Test
+    void rendersNoSecretAppleCaldavProfileMetadata() {
+        AppleMobileConfigProfileRenderer renderer = new AppleMobileConfigProfileRenderer("https://files.weave.local");
+
+        AppleMobileConfigProfile profile = renderer.renderUnsignedNoSecretProfile(
+                new CalendarPrincipal("subject-123", "maria"));
+
+        String plist = new String(profile.content(), StandardCharsets.UTF_8);
+        assertThat(profile.filename()).isEqualTo("weave-calendar-maria.mobileconfig");
+        assertThat(plist)
+                .contains("<string>com.apple.caldav.account</string>")
+                .contains("<key>CalDAVHostName</key>")
+                .contains("<string>files.weave.local</string>")
+                .contains("<key>CalDAVPort</key>")
+                .contains("<integer>443</integer>")
+                .contains("<key>CalDAVUseSSL</key>")
+                .contains("<true/>")
+                .contains("<key>CalDAVPrincipalURL</key>")
+                .contains("<string>/remote.php/dav/principals/users/maria/</string>")
+                .contains("<key>CalDAVUsername</key>")
+                .contains("<string>maria</string>");
+    }
+
+    @Test
+    void doesNotRenderPasswordBearerTokenOrBackendActorSecret() {
+        AppleMobileConfigProfileRenderer renderer = new AppleMobileConfigProfileRenderer("https://files.weave.local");
+
+        AppleMobileConfigProfile profile = renderer.renderUnsignedNoSecretProfile(
+                new CalendarPrincipal("user-with-backend-secret-sentinel", "alice"));
+
+        String plist = new String(profile.content(), StandardCharsets.UTF_8);
+        assertThat(plist)
+                .doesNotContain("CalDAVPassword")
+                .doesNotContain("Password")
+                .doesNotContain("Authorization")
+                .doesNotContain("Bearer")
+                .doesNotContain("backend-actor-token")
+                .doesNotContain("WEAVE_CALDAV_BACKEND_TOKEN")
+                .doesNotContain("user-with-backend-secret-sentinel");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds authenticated `GET /api/calendar/client-setup/apple.mobileconfig` as the reserved Apple profile download route.
- Keeps the route fail-closed with `503 calendar-apple-profile-unavailable` until signed profile generation is configured.
- Adds a tested unsigned no-secret `.mobileconfig` renderer for the future signer input; it includes CalDAV host/port/SSL/principal/username only and omits `CalDAVPassword`.
- Documents that password/token-bearing profiles remain blocked until revocable per-client credential issuance/revocation exists.

## Safety boundary

- Does not expose backend actor credentials, bearer tokens, user passwords, or static secrets.
- Does not enable private `{user}` calendar access.
- Leaves Apple setup unavailable in client readiness until signing/credential blockers are resolved.

## Validation

- `./gradlew test --tests '*AppleMobileConfigProfileRendererTest' --tests '*FilesCalendarFacadeControllerTest' --tests '*OpenApiDocumentationTest'`
- `./gradlew test && git diff --check`

Refs #56
