### PR TITLE
feat: add boards event normalizer preview contracts

### DIFF
--- a/docs/boards-preview-contract.md
+++ b/docs/boards-preview-contract.md
@@ -12,9 +12,9 @@ Implemented now:
 - A repository port that hides provider pagination, IDs, vocabulary, and raw errors from callers.
 - A support-safe error vocabulary aligned with the workspace spec.
 - A Vikunja HTTP/status error mapper that converts provider failures into Weave codes without leaking raw provider messages, URLs, or tokens.
-- A no-op event publisher boundary plus preview JSON/OpenAPI schema artifacts under `src/main/resources/contracts/`.
+- A provider-neutral task/board event normalizer, no-op event publisher boundary, and preview JSON/OpenAPI schema artifacts under `src/main/resources/contracts/`.
 - A first Vikunja adapter boundary and mapper that translates Vikunja projects/buckets/tasks into Weave concepts.
-- A fail-closed Vikunja repository placeholder that advertises preview capabilities but does not perform runtime HTTP calls.
+- Fail-closed Vikunja, OpenProject, and Nextcloud Deck repository placeholders that advertise preview/benchmark/bridge capabilities but do not perform runtime HTTP calls.
 
 Not implemented now:
 
@@ -43,6 +43,28 @@ Vikunja is the first strategic adapter boundary because it is lightweight, self-
 - Vikunja task → Weave task item
 
 The repository placeholder fails closed with `provider_unavailable` until a promotion spec defines authentication, HTTP client behavior, persistence/sync expectations, route DTOs, and validation gates. The adapter boundary now also contains the support-safe HTTP/status mapping expected once real Vikunja calls are introduced: unauthorized, forbidden, not found, conflict, validation, rate limit, offline, provider unavailable, and unknown failures are normalized before reaching product/API code.
+
+## Provider spike contracts
+
+The backend preview layer now declares three disabled adapter contracts against the same `BoardsRepository` port:
+
+- `VikunjaBoardsRepository`: first adapter candidate; supports comments, attachments, non-destructive archive, webhooks, incremental sync, checklists, and accessible non-drag move commands in the contract, but is disabled for runtime use.
+- `OpenProjectBoardsRepository`: accessibility/mature-workflow benchmark; declares comments, attachments, non-destructive archive, and custom fields as benchmark capabilities, but is not the first runtime provider.
+- `NextcloudDeckBoardsRepository`: Nextcloud-adjacent bridge/import candidate; declares comments, attachments, and non-destructive archive, but avoids claiming webhooks or incremental sync until tested.
+
+All three fail closed with support-safe `provider_unavailable` errors until a promotion spec defines auth, route DTOs, OpenAPI publication, smoke/E2E coverage, export/backup, and accessibility gates.
+
+## Event normalizer
+
+`TaskBoardEventNormalizer` is the backend-owned preview boundary for provider activity from Vikunja webhooks, OpenProject activity records, Deck polling/ETag changes, or a later connector gateway. It:
+
+- accepts provider draft events through `TaskBoardEventInput`;
+- emits provider-neutral `TaskBoardEvent` envelopes with stable idempotency keys;
+- records provider identity only as support/sync metadata;
+- preserves ordering inputs such as source event id and provider timestamps in payload fields without publishing routes;
+- redacts support-unsafe payload keys such as tokens, secrets, raw messages, credentials, authorisation headers, and provider URLs before support-safe events leave the adapter boundary.
+
+This is still preview-only and has no notification, audit, webhook, or Release 1 runtime publication.
 
 ## Contract artifacts
 

--- a/src/main/java/com/massimotter/weave/backend/boards/deck/NextcloudDeckBoardsRepository.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/deck/NextcloudDeckBoardsRepository.java
@@ -1,0 +1,67 @@
+package com.massimotter.weave.backend.boards.deck;
+
+import com.massimotter.weave.backend.boards.domain.Board;
+import com.massimotter.weave.backend.boards.domain.BoardCapability;
+import com.massimotter.weave.backend.boards.domain.BoardColumn;
+import com.massimotter.weave.backend.boards.domain.BoardProviderCapabilities;
+import com.massimotter.weave.backend.boards.domain.Label;
+import com.massimotter.weave.backend.boards.domain.ProviderKind;
+import com.massimotter.weave.backend.boards.domain.TaskAttachment;
+import com.massimotter.weave.backend.boards.domain.TaskComment;
+import com.massimotter.weave.backend.boards.domain.TaskItem;
+import com.massimotter.weave.backend.boards.domain.WeaveProject;
+import com.massimotter.weave.backend.boards.port.BoardPage;
+import com.massimotter.weave.backend.boards.port.BoardQuery;
+import com.massimotter.weave.backend.boards.port.BoardsRepository;
+import com.massimotter.weave.backend.boards.port.CreateTaskCommand;
+import com.massimotter.weave.backend.boards.port.MoveTaskCommand;
+import com.massimotter.weave.backend.boards.port.TaskQuery;
+import com.massimotter.weave.backend.boards.support.BoardsErrorCode;
+import com.massimotter.weave.backend.boards.support.BoardsException;
+
+import java.util.EnumSet;
+import java.util.Optional;
+
+/**
+ * Disabled Nextcloud Deck bridge adapter contract. Deck is evaluated as a bridge
+ * because Nextcloud is already in the Weave stack, but Deck board/stack/card
+ * vocabulary must stay behind this backend boundary.
+ */
+public final class NextcloudDeckBoardsRepository implements BoardsRepository {
+
+    @Override
+    public BoardProviderCapabilities capabilities() {
+        return new BoardProviderCapabilities(
+                ProviderKind.NEXTCLOUD_DECK,
+                false,
+                EnumSet.of(
+                        BoardCapability.COMMENTS,
+                        BoardCapability.ATTACHMENTS,
+                        BoardCapability.NON_DESTRUCTIVE_ARCHIVE),
+                EnumSet.of(
+                        BoardCapability.WEBHOOK_EVENTS,
+                        BoardCapability.INCREMENTAL_SYNC,
+                        BoardCapability.CHECKLISTS,
+                        BoardCapability.CUSTOM_FIELDS,
+                        BoardCapability.ACCESSIBLE_NON_DRAG_MOVES),
+                "Nextcloud Deck is a disabled bridge/import adapter contract, not the Weave product model or a Release 1 runtime provider.");
+    }
+
+    @Override public BoardPage<WeaveProject> listProjects(BoardQuery query) { throw disabled(); }
+    @Override public BoardPage<Board> listBoards(String projectId, BoardQuery query) { throw disabled(); }
+    @Override public Optional<Board> findBoard(String boardId) { throw disabled(); }
+    @Override public BoardPage<BoardColumn> listColumns(String boardId, BoardQuery query) { throw disabled(); }
+    @Override public BoardPage<TaskItem> listTasks(String boardId, TaskQuery query) { throw disabled(); }
+    @Override public BoardPage<Label> listLabels(String boardId, BoardQuery query) { throw disabled(); }
+    @Override public BoardPage<TaskComment> listComments(String taskId, BoardQuery query) { throw disabled(); }
+    @Override public BoardPage<TaskAttachment> listAttachments(String taskId, BoardQuery query) { throw disabled(); }
+    @Override public TaskItem createTask(CreateTaskCommand command) { throw disabled(); }
+    @Override public TaskItem moveTask(MoveTaskCommand command) { throw disabled(); }
+    @Override public TaskItem completeTask(String taskId) { throw disabled(); }
+
+    private BoardsException disabled() {
+        return new BoardsException(
+                BoardsErrorCode.PROVIDER_UNAVAILABLE,
+                "Nextcloud Deck Boards/Tasks adapter is bridge-only and disabled until a promotion spec enables backend routes.");
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/events/TaskBoardEventInput.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/events/TaskBoardEventInput.java
@@ -1,0 +1,45 @@
+package com.massimotter.weave.backend.boards.events;
+
+import com.massimotter.weave.backend.boards.domain.EventRedactionLevel;
+import com.massimotter.weave.backend.boards.domain.ProviderRef;
+import com.massimotter.weave.backend.boards.domain.TaskBoardEventType;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Provider-facing draft event accepted by the preview Boards/Tasks event normalizer.
+ * Adapters may populate this from webhooks, polling snapshots, or provider audit/activity
+ * records without leaking provider vocabulary beyond this boundary.
+ */
+public record TaskBoardEventInput(
+        String sourceEventId,
+        TaskBoardEventType type,
+        String actorRef,
+        Instant occurredAt,
+        String workspaceId,
+        String projectId,
+        String boardId,
+        String taskId,
+        ProviderRef providerRef,
+        EventRedactionLevel redactionLevel,
+        Map<String, Object> payload) {
+
+    public TaskBoardEventInput {
+        type = requireNonNull(type, "type must not be null");
+        actorRef = requireText(actorRef, "actorRef");
+        occurredAt = requireNonNull(occurredAt, "occurredAt must not be null");
+        workspaceId = requireText(workspaceId, "workspaceId");
+        redactionLevel = requireNonNull(redactionLevel, "redactionLevel must not be null");
+        payload = Map.copyOf(requireNonNull(payload, "payload must not be null"));
+    }
+
+    private static String requireText(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/events/TaskBoardEventNormalizer.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/events/TaskBoardEventNormalizer.java
@@ -1,0 +1,154 @@
+package com.massimotter.weave.backend.boards.events;
+
+import com.massimotter.weave.backend.boards.domain.ColumnSemanticStatus;
+import com.massimotter.weave.backend.boards.domain.EventRedactionLevel;
+import com.massimotter.weave.backend.boards.domain.ProviderKind;
+import com.massimotter.weave.backend.boards.domain.ProviderRef;
+import com.massimotter.weave.backend.boards.domain.TaskBoardEvent;
+import com.massimotter.weave.backend.boards.domain.TaskBoardEventType;
+import com.massimotter.weave.backend.boards.domain.TaskPriority;
+import com.massimotter.weave.backend.boards.domain.TaskStatus;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Converts provider-specific activity records into the provider-neutral Weave
+ * Boards/Tasks event envelope. This is intentionally backend-owned preview code:
+ * Flutter consumes Weave task state/events, never Vikunja/OpenProject/Deck payloads.
+ */
+public final class TaskBoardEventNormalizer {
+
+    private static final String REDACTED = "[redacted]";
+
+    public TaskBoardEvent normalize(TaskBoardEventInput input) {
+        Map<String, Object> payload = supportSafePayload(input);
+        return new TaskBoardEvent(
+                idempotencyKey(input),
+                input.type(),
+                input.actorRef(),
+                input.occurredAt(),
+                input.workspaceId(),
+                input.projectId(),
+                input.boardId(),
+                input.taskId(),
+                input.providerRef(),
+                input.redactionLevel(),
+                payload);
+    }
+
+    private String idempotencyKey(TaskBoardEventInput input) {
+        ProviderRef ref = input.providerRef();
+        String provider = providerName(ref);
+        if (hasText(input.sourceEventId())) {
+            return provider + ":" + input.sourceEventId().trim();
+        }
+        String externalId = ref == null ? null : ref.externalId();
+        if (hasText(externalId)) {
+            return String.join(":",
+                    provider,
+                    externalId.trim(),
+                    input.type().contractName(),
+                    input.occurredAt().toString());
+        }
+        return String.join(":",
+                input.workspaceId(),
+                valueOrUnknown(input.taskId()),
+                input.type().contractName(),
+                input.occurredAt().toString());
+    }
+
+    private Map<String, Object> supportSafePayload(TaskBoardEventInput input) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("sourceProvider", providerName(input.providerRef()));
+        if (hasText(input.sourceEventId())) {
+            payload.put("sourceEventId", input.sourceEventId().trim());
+        }
+        payload.put("eventType", input.type().contractName());
+        input.payload().entrySet().stream()
+                .filter(entry -> entry.getKey() != null && !entry.getKey().isBlank())
+                .filter(entry -> entry.getValue() != null)
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(entry -> payload.put(entry.getKey(), sanitizeValue(entry.getKey(), entry.getValue(), input.redactionLevel())));
+        return Map.copyOf(payload);
+    }
+
+    private Object sanitizeValue(String key, Object value, EventRedactionLevel redactionLevel) {
+        if (value == null) {
+            return null;
+        }
+        if (isSensitiveKey(key) && redactionLevel != EventRedactionLevel.PRIVATE_CONTENT) {
+            return REDACTED;
+        }
+        return sanitizeObject(value, redactionLevel);
+    }
+
+    private Object sanitizeObject(Object value, EventRedactionLevel redactionLevel) {
+        if (value == null || value instanceof String || value instanceof Number || value instanceof Boolean) {
+            return value;
+        }
+        if (value instanceof Instant instant) {
+            return instant.toString();
+        }
+        if (value instanceof TaskBoardEventType eventType) {
+            return eventType.contractName();
+        }
+        if (value instanceof ProviderKind providerKind) {
+            return providerKind.contractName();
+        }
+        if (value instanceof TaskStatus taskStatus) {
+            return taskStatus.contractName();
+        }
+        if (value instanceof ColumnSemanticStatus columnStatus) {
+            return columnStatus.contractName();
+        }
+        if (value instanceof TaskPriority taskPriority) {
+            return taskPriority.name().toLowerCase();
+        }
+        if (value instanceof Map<?, ?> map) {
+            Map<String, Object> sanitized = new LinkedHashMap<>();
+            map.entrySet().stream()
+                    .filter(entry -> entry.getKey() instanceof String && !((String) entry.getKey()).isBlank())
+                    .sorted((left, right) -> ((String) left.getKey()).compareTo((String) right.getKey()))
+                    .forEach(entry -> sanitized.put(
+                            (String) entry.getKey(),
+                            sanitizeValue((String) entry.getKey(), entry.getValue(), redactionLevel)));
+            return Map.copyOf(sanitized);
+        }
+        if (value instanceof Iterable<?> iterable) {
+            List<Object> sanitized = new ArrayList<>();
+            for (Object item : iterable) {
+                sanitized.add(sanitizeObject(item, redactionLevel));
+            }
+            return List.copyOf(sanitized);
+        }
+        return value.toString();
+    }
+
+    private boolean isSensitiveKey(String key) {
+        String normalized = key.toLowerCase().replace("_", "").replace("-", "");
+        return normalized.contains("token")
+                || normalized.contains("secret")
+                || normalized.contains("password")
+                || normalized.contains("authorization")
+                || normalized.contains("credential")
+                || normalized.contains("rawmessage")
+                || normalized.equals("url")
+                || normalized.endsWith("url");
+    }
+
+    private String providerName(ProviderRef ref) {
+        return ref == null ? ProviderKind.UNKNOWN.contractName() : ref.provider().contractName();
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private String valueOrUnknown(String value) {
+        return hasText(value) ? value.trim() : "unknown-task";
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/boards/openproject/OpenProjectBoardsRepository.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/openproject/OpenProjectBoardsRepository.java
@@ -1,0 +1,67 @@
+package com.massimotter.weave.backend.boards.openproject;
+
+import com.massimotter.weave.backend.boards.domain.Board;
+import com.massimotter.weave.backend.boards.domain.BoardCapability;
+import com.massimotter.weave.backend.boards.domain.BoardColumn;
+import com.massimotter.weave.backend.boards.domain.BoardProviderCapabilities;
+import com.massimotter.weave.backend.boards.domain.Label;
+import com.massimotter.weave.backend.boards.domain.ProviderKind;
+import com.massimotter.weave.backend.boards.domain.TaskAttachment;
+import com.massimotter.weave.backend.boards.domain.TaskComment;
+import com.massimotter.weave.backend.boards.domain.TaskItem;
+import com.massimotter.weave.backend.boards.domain.WeaveProject;
+import com.massimotter.weave.backend.boards.port.BoardPage;
+import com.massimotter.weave.backend.boards.port.BoardQuery;
+import com.massimotter.weave.backend.boards.port.BoardsRepository;
+import com.massimotter.weave.backend.boards.port.CreateTaskCommand;
+import com.massimotter.weave.backend.boards.port.MoveTaskCommand;
+import com.massimotter.weave.backend.boards.port.TaskQuery;
+import com.massimotter.weave.backend.boards.support.BoardsErrorCode;
+import com.massimotter.weave.backend.boards.support.BoardsException;
+
+import java.util.EnumSet;
+import java.util.Optional;
+
+/**
+ * Disabled OpenProject benchmark adapter contract. OpenProject remains an
+ * accessibility/workflow benchmark, not the first runtime provider, until a later
+ * promotion spec defines auth, API filters, synchronization, and route DTOs.
+ */
+public final class OpenProjectBoardsRepository implements BoardsRepository {
+
+    @Override
+    public BoardProviderCapabilities capabilities() {
+        return new BoardProviderCapabilities(
+                ProviderKind.OPEN_PROJECT,
+                false,
+                EnumSet.of(
+                        BoardCapability.COMMENTS,
+                        BoardCapability.ATTACHMENTS,
+                        BoardCapability.NON_DESTRUCTIVE_ARCHIVE,
+                        BoardCapability.CUSTOM_FIELDS),
+                EnumSet.of(
+                        BoardCapability.WEBHOOK_EVENTS,
+                        BoardCapability.INCREMENTAL_SYNC,
+                        BoardCapability.CHECKLISTS,
+                        BoardCapability.ACCESSIBLE_NON_DRAG_MOVES),
+                "OpenProject is a disabled accessibility and mature-workflow benchmark adapter contract, not a Release 1 runtime provider.");
+    }
+
+    @Override public BoardPage<WeaveProject> listProjects(BoardQuery query) { throw disabled(); }
+    @Override public BoardPage<Board> listBoards(String projectId, BoardQuery query) { throw disabled(); }
+    @Override public Optional<Board> findBoard(String boardId) { throw disabled(); }
+    @Override public BoardPage<BoardColumn> listColumns(String boardId, BoardQuery query) { throw disabled(); }
+    @Override public BoardPage<TaskItem> listTasks(String boardId, TaskQuery query) { throw disabled(); }
+    @Override public BoardPage<Label> listLabels(String boardId, BoardQuery query) { throw disabled(); }
+    @Override public BoardPage<TaskComment> listComments(String taskId, BoardQuery query) { throw disabled(); }
+    @Override public BoardPage<TaskAttachment> listAttachments(String taskId, BoardQuery query) { throw disabled(); }
+    @Override public TaskItem createTask(CreateTaskCommand command) { throw disabled(); }
+    @Override public TaskItem moveTask(MoveTaskCommand command) { throw disabled(); }
+    @Override public TaskItem completeTask(String taskId) { throw disabled(); }
+
+    private BoardsException disabled() {
+        return new BoardsException(
+                BoardsErrorCode.PROVIDER_UNAVAILABLE,
+                "OpenProject Boards/Tasks adapter is benchmark-only and disabled until a promotion spec enables backend routes.");
+    }
+}

--- a/src/main/resources/contracts/task-board-event.schema.json
+++ b/src/main/resources/contracts/task-board-event.schema.json
@@ -60,6 +60,7 @@
     },
     "payload": {
       "type": "object",
+      "description": "Provider-neutral, redacted activity details. Normalized payloads may include sourceProvider, sourceEventId, eventType, changed field identifiers, ordering/cursor hints, and support-safe conflict details.",
       "additionalProperties": true
     }
   },

--- a/src/test/java/com/massimotter/weave/backend/boards/BoardProviderSpikeContractsTest.java
+++ b/src/test/java/com/massimotter/weave/backend/boards/BoardProviderSpikeContractsTest.java
@@ -1,0 +1,67 @@
+package com.massimotter.weave.backend.boards;
+
+import com.massimotter.weave.backend.boards.deck.NextcloudDeckBoardsRepository;
+import com.massimotter.weave.backend.boards.domain.BoardCapability;
+import com.massimotter.weave.backend.boards.domain.ProviderKind;
+import com.massimotter.weave.backend.boards.openproject.OpenProjectBoardsRepository;
+import com.massimotter.weave.backend.boards.support.BoardsErrorCode;
+import com.massimotter.weave.backend.boards.support.BoardsException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class BoardProviderSpikeContractsTest {
+
+    @Test
+    void openProjectBenchmarkAdapterDeclaresCapabilitiesButStaysDisabled() {
+        var repository = new OpenProjectBoardsRepository();
+
+        var capabilities = repository.capabilities();
+
+        assertThat(capabilities.provider()).isEqualTo(ProviderKind.OPEN_PROJECT);
+        assertThat(capabilities.enabled()).isFalse();
+        assertThat(capabilities.supported()).contains(
+                BoardCapability.COMMENTS,
+                BoardCapability.ATTACHMENTS,
+                BoardCapability.NON_DESTRUCTIVE_ARCHIVE,
+                BoardCapability.CUSTOM_FIELDS);
+        assertThat(capabilities.unsupported()).contains(
+                BoardCapability.WEBHOOK_EVENTS,
+                BoardCapability.INCREMENTAL_SYNC,
+                BoardCapability.ACCESSIBLE_NON_DRAG_MOVES);
+        assertThat(capabilities.supportSafeSummary()).contains("benchmark").contains("Release 1");
+        assertThatThrownBy(() -> repository.listProjects(null))
+                .isInstanceOf(BoardsException.class)
+                .satisfies(error -> assertThat(((BoardsException) error).code())
+                        .isEqualTo(BoardsErrorCode.PROVIDER_UNAVAILABLE))
+                .hasMessageContaining("benchmark-only")
+                .hasMessageContaining("disabled");
+    }
+
+    @Test
+    void deckBridgeAdapterDeclaresCapabilitiesButStaysDisabled() {
+        var repository = new NextcloudDeckBoardsRepository();
+
+        var capabilities = repository.capabilities();
+
+        assertThat(capabilities.provider()).isEqualTo(ProviderKind.NEXTCLOUD_DECK);
+        assertThat(capabilities.enabled()).isFalse();
+        assertThat(capabilities.supported()).contains(
+                BoardCapability.COMMENTS,
+                BoardCapability.ATTACHMENTS,
+                BoardCapability.NON_DESTRUCTIVE_ARCHIVE);
+        assertThat(capabilities.unsupported()).contains(
+                BoardCapability.WEBHOOK_EVENTS,
+                BoardCapability.INCREMENTAL_SYNC,
+                BoardCapability.CUSTOM_FIELDS,
+                BoardCapability.ACCESSIBLE_NON_DRAG_MOVES);
+        assertThat(capabilities.supportSafeSummary()).contains("bridge").contains("Release 1");
+        assertThatThrownBy(() -> repository.listProjects(null))
+                .isInstanceOf(BoardsException.class)
+                .satisfies(error -> assertThat(((BoardsException) error).code())
+                        .isEqualTo(BoardsErrorCode.PROVIDER_UNAVAILABLE))
+                .hasMessageContaining("bridge-only")
+                .hasMessageContaining("disabled");
+    }
+}

--- a/src/test/java/com/massimotter/weave/backend/boards/TaskBoardEventNormalizerTest.java
+++ b/src/test/java/com/massimotter/weave/backend/boards/TaskBoardEventNormalizerTest.java
@@ -1,0 +1,155 @@
+package com.massimotter.weave.backend.boards;
+
+import com.massimotter.weave.backend.boards.domain.EventRedactionLevel;
+import com.massimotter.weave.backend.boards.domain.ProviderKind;
+import com.massimotter.weave.backend.boards.domain.ProviderRef;
+import com.massimotter.weave.backend.boards.domain.TaskBoardEventType;
+import com.massimotter.weave.backend.boards.domain.TaskPriority;
+import com.massimotter.weave.backend.boards.domain.TaskStatus;
+import com.massimotter.weave.backend.boards.events.TaskBoardEventInput;
+import com.massimotter.weave.backend.boards.events.TaskBoardEventNormalizer;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TaskBoardEventNormalizerTest {
+
+    private final TaskBoardEventNormalizer normalizer = new TaskBoardEventNormalizer();
+
+    @Test
+    void normalizesVikunjaMoveWebhookIntoProviderNeutralEnvelope() {
+        var event = normalizer.normalize(new TaskBoardEventInput(
+                "webhook-42",
+                TaskBoardEventType.TASK_MOVED,
+                "user:alice",
+                Instant.parse("2026-05-14T11:00:00Z"),
+                "workspace:weave",
+                "vikunja:project:7",
+                "vikunja:board:7",
+                "vikunja:task:99",
+                new ProviderRef(
+                        ProviderKind.VIKUNJA,
+                        "task:99",
+                        URI.create("https://tasks.example.invalid/tasks/99"),
+                        "42",
+                        "etag-42",
+                        Instant.parse("2026-05-14T11:00:00Z")),
+                EventRedactionLevel.SUPPORT_SAFE,
+                Map.of(
+                        "fromColumnId", "vikunja:column:1",
+                        "toColumnId", "vikunja:column:2",
+                        "position", 3,
+                        "statusAfter", TaskStatus.OPEN)));
+
+        assertThat(event.idempotencyKey()).isEqualTo("vikunja:webhook-42");
+        assertThat(event.type()).isEqualTo(TaskBoardEventType.TASK_MOVED);
+        assertThat(event.providerRef().provider()).isEqualTo(ProviderKind.VIKUNJA);
+        assertThat(event.payload()).containsEntry("sourceProvider", "vikunja");
+        assertThat(event.payload()).containsEntry("eventType", "task.moved");
+        assertThat(event.payload()).containsEntry("fromColumnId", "vikunja:column:1");
+        assertThat(event.payload()).containsEntry("toColumnId", "vikunja:column:2");
+        assertThat(event.payload()).containsEntry("statusAfter", "open");
+    }
+
+    @Test
+    void normalizesOpenProjectActivityWithoutBindingToActionBoardVocabulary() {
+        var event = normalizer.normalize(new TaskBoardEventInput(
+                "activity-987",
+                TaskBoardEventType.DUE_DATE_CHANGED,
+                "openproject:user:12",
+                Instant.parse("2026-05-14T12:00:00Z"),
+                "workspace:weave",
+                "openproject:project:5",
+                "openproject:board:11",
+                "openproject:work-package:321",
+                ProviderRef.of(ProviderKind.OPEN_PROJECT, "work_package:321"),
+                EventRedactionLevel.WORKSPACE_INTERNAL,
+                Map.of(
+                        "providerObjectKind", "work_package",
+                        "dueDateBefore", "2026-05-20",
+                        "dueDateAfter", "2026-05-27")));
+
+        assertThat(event.idempotencyKey()).isEqualTo("openproject:activity-987");
+        assertThat(event.type().contractName()).isEqualTo("due_date.changed");
+        assertThat(event.payload()).containsEntry("providerObjectKind", "work_package");
+        assertThat(event.payload()).doesNotContainKey("actionBoardColumnName");
+    }
+
+    @Test
+    void normalizesDeckPollingChangeWithDeterministicFallbackIdempotencyKey() {
+        var event = normalizer.normalize(new TaskBoardEventInput(
+                null,
+                TaskBoardEventType.LABEL_CHANGED,
+                "nextcloud:user:admin",
+                Instant.parse("2026-05-14T13:00:00Z"),
+                "workspace:weave",
+                "deck:board:10",
+                "deck:board:10",
+                "deck:card:81",
+                ProviderRef.of(ProviderKind.NEXTCLOUD_DECK, "card:81"),
+                EventRedactionLevel.SUPPORT_SAFE,
+                Map.of(
+                        "labelRefsBefore", List.of("deck:label:37"),
+                        "labelRefsAfter", List.of("deck:label:37", "deck:label:39"),
+                        "priorityAfter", TaskPriority.HIGH)));
+
+        assertThat(event.idempotencyKey())
+                .isEqualTo("nextcloud-deck:card:81:label.changed:2026-05-14T13:00:00Z");
+        assertThat(event.payload()).containsEntry("sourceProvider", "nextcloud-deck");
+        assertThat(event.payload()).containsEntry("priorityAfter", "high");
+        assertThat(event.payload().get("labelRefsAfter")).isEqualTo(List.of("deck:label:37", "deck:label:39"));
+    }
+
+    @Test
+    void redactsSensitiveProviderDetailsFromSupportSafePayloads() {
+        var event = normalizer.normalize(new TaskBoardEventInput(
+                "conflict-1",
+                TaskBoardEventType.SYNC_CONFLICT_DETECTED,
+                "system:sync",
+                Instant.parse("2026-05-14T14:00:00Z"),
+                "workspace:weave",
+                "project:1",
+                "board:1",
+                "task:1",
+                ProviderRef.of(ProviderKind.VIKUNJA, "task:1"),
+                EventRedactionLevel.SUPPORT_SAFE,
+                Map.of(
+                        "rawMessage", "Bearer token leaked by provider",
+                        "requestUrl", "https://tasks.example.invalid/tasks/1?token=secret",
+                        "authorization", "Bearer abc",
+                        "token", "abc",
+                        "supportSafeReason", "etag_conflict",
+                        "nested", Map.of("clientSecret", "shh", "attempt", 2))));
+
+        assertThat(event.payload()).containsEntry("rawMessage", "[redacted]");
+        assertThat(event.payload()).containsEntry("requestUrl", "[redacted]");
+        assertThat(event.payload()).containsEntry("authorization", "[redacted]");
+        assertThat(event.payload()).containsEntry("token", "[redacted]");
+        assertThat(event.payload()).containsEntry("supportSafeReason", "etag_conflict");
+        assertThat(event.payload().get("nested")).isEqualTo(Map.of("attempt", 2, "clientSecret", "[redacted]"));
+    }
+
+    @Test
+    void validatesRequiredEnvelopeFieldsBeforePublication() {
+        assertThatThrownBy(() -> new TaskBoardEventInput(
+                "event-1",
+                TaskBoardEventType.TASK_CREATED,
+                " ",
+                Instant.parse("2026-05-14T15:00:00Z"),
+                "workspace:weave",
+                null,
+                null,
+                null,
+                ProviderRef.of(ProviderKind.UNKNOWN, "event:1"),
+                EventRedactionLevel.PUBLIC_METADATA,
+                Map.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("actorRef");
+    }
+}


### PR DESCRIPTION
## Summary

Adds concrete preview-only backend progress for Boards/Tasks connectors: a provider-neutral task/board event normalizer plus disabled OpenProject and Nextcloud Deck adapter contracts alongside the existing Vikunja boundary.

## Issue mapping

- Refs masssi164/weave#123: provider-neutral activity event normalizer and contract schema notes.
- Refs masssi164/weave#119: keeps Vikunja as first adapter boundary and event source candidate.
- Refs masssi164/weave#120: adds disabled OpenProject benchmark adapter contract.
- Refs masssi164/weave#121: adds disabled Nextcloud Deck bridge/import adapter contract.
- Refs #43 and #38: keeps connector/provider API behind backend ports, with no public runtime routes yet.

## Changes

- Adds `TaskBoardEventInput` and `TaskBoardEventNormalizer` for provider activity from webhooks, polling, or activity APIs.
- Produces stable idempotency keys and support-safe payload redaction for tokens, secrets, auth headers, provider URLs, and raw messages.
- Adds disabled `OpenProjectBoardsRepository` and `NextcloudDeckBoardsRepository` contracts using the existing `BoardsRepository` port.
- Updates preview contract docs and task-board event schema description.
- Adds unit tests for Vikunja/OpenProject/Deck event examples, redaction, validation, and disabled adapter capabilities.

## Validation

- `./gradlew test --tests 'com.massimotter.weave.backend.boards.*'`
- `./gradlew test`

## Notes

Preview-only: no Spring routes, no live provider credentials, no runtime HTTP calls, no Release 1 surface, no claims of live integration.
