### PR TITLE
feat(boards): add hidden preview runtime facade

### DIFF
--- a/docs/boards-preview-contract.md
+++ b/docs/boards-preview-contract.md
@@ -1,6 +1,6 @@
 # Boards/Tasks preview contract
 
-Boards/Tasks is a provider-neutral, post-Release-1 preview slice. It is **not** a Release 1 product surface, has no published backend routes, and must remain hidden/feature-flagged until a later promotion spec defines API routes, auth scopes, DTO compatibility, OpenAPI publication, runtime provider setup, smoke/E2E, and accessibility gates.
+Boards/Tasks is a provider-neutral, post-Release-1 preview slice. It is **not** a Release 1 product surface. The only reachable runtime slice is a hidden, authenticated, feature-flagged local preview facade; live provider adapters remain disabled until a later promotion spec defines provider auth, DTO compatibility, OpenAPI publication, runtime setup, smoke/E2E, and accessibility gates.
 
 This document is intentionally separate from Release 1 screenshots and product-surface documentation. Do not add Boards/Tasks screenshots to the main Product screenshots section unless the module is fully navigable and release-enabled by a later spec.
 
@@ -15,14 +15,35 @@ Implemented now:
 - A provider-neutral task/board event normalizer, no-op event publisher boundary, and preview JSON/OpenAPI schema artifacts under `src/main/resources/contracts/`.
 - A first Vikunja adapter boundary and mapper that translates Vikunja projects/buckets/tasks into Weave concepts.
 - Fail-closed Vikunja, OpenProject, and Nextcloud Deck repository placeholders that advertise preview/benchmark/bridge capabilities but do not perform runtime HTTP calls.
+- A hidden local/in-memory backend preview facade behind `weave.boards.preview.runtime-enabled` that proves provider-neutral create, move, and complete operations without drag-only UI assumptions.
 
 Not implemented now:
 
-- No Spring MVC controller routes.
 - No Release 1 navigation or product enablement.
-- No provider runtime configuration, secrets, Caddy routes, or smoke checks.
+- No live provider runtime configuration, secrets, Caddy routes, or smoke checks.
 - No user-facing screenshots.
 - No notifications, audit streams, webhooks, or automation consumers.
+
+## Hidden preview API
+
+The hidden preview API is deliberately narrow and disabled by default:
+
+- `GET /api/boards/preview`
+- `POST /api/boards/{boardId}/tasks`
+- `POST /api/boards/tasks/{taskId}/move`
+- `POST /api/boards/tasks/{taskId}/complete`
+
+All routes require the normal authenticated `weave:workspace` backend boundary. They return provider-neutral Weave domain shapes and support-safe `boards-*` errors. The local adapter stores only in-memory preview data, exposes `releaseStatus = post-release-hidden-preview`, and must not be documented as a Release 1/customer-ready module.
+
+## 2026-05-14 issue/spec matrix
+
+| Track | Source | This implementation wave | Status |
+| --- | --- | --- | --- |
+| Boards/Tasks domain | Workspace spec `specs/14-boards-tasks-domain-and-provider-adapter-contract.md`; `weave` issues #119-#123 | Adds the hidden backend runtime slice and lets the Flutter hidden preview consume it when authenticated. | Implemented as post-Release hidden preview; not Release 1/product-enabled. |
+| Calendar private/workspace model | `weave-backend` #52 | Existing calendar facade remains workspace-scoped and private-user CalDAV stays fail-closed until the access model is finished. | Deferred from this Boards runtime PR; do not add fake private calendar UI. |
+| Calendar external CalDAV credentials/profile | `weave-backend` #56; `weave-infra` #54 | No credential/profile issuing in this wave because revocation, storage, redaction, and support-bundle handling are the acceptance gate. | Deferred; keep client setup secret-free and truthful. |
+
+Calendar follow-up must land as a separate security-focused wave before Apple `.mobileconfig`, DAVx5, desktop CalDAV discovery, or user-private calendar access is exposed.
 
 ## Provider-neutral model
 

--- a/src/main/java/com/massimotter/weave/backend/boards/domain/BoardCapability.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/domain/BoardCapability.java
@@ -1,5 +1,7 @@
 package com.massimotter.weave.backend.boards.domain;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public enum BoardCapability {
     COMMENTS("comments"),
     ATTACHMENTS("attachments"),
@@ -16,6 +18,7 @@ public enum BoardCapability {
         this.contractName = contractName;
     }
 
+    @JsonValue
     public String contractName() {
         return contractName;
     }

--- a/src/main/java/com/massimotter/weave/backend/boards/domain/ColumnSemanticStatus.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/domain/ColumnSemanticStatus.java
@@ -1,5 +1,7 @@
 package com.massimotter.weave.backend.boards.domain;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public enum ColumnSemanticStatus {
     NOT_STARTED("not_started"),
     IN_PROGRESS("in_progress"),
@@ -13,6 +15,7 @@ public enum ColumnSemanticStatus {
         this.contractName = contractName;
     }
 
+    @JsonValue
     public String contractName() {
         return contractName;
     }

--- a/src/main/java/com/massimotter/weave/backend/boards/domain/ProviderKind.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/domain/ProviderKind.java
@@ -1,5 +1,7 @@
 package com.massimotter.weave.backend.boards.domain;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 /**
  * Provider identity used only for diagnostics, export, migration, and sync metadata.
  * User-facing Boards language stays Weave-owned and provider-neutral.
@@ -17,6 +19,7 @@ public enum ProviderKind {
         this.contractName = contractName;
     }
 
+    @JsonValue
     public String contractName() {
         return contractName;
     }

--- a/src/main/java/com/massimotter/weave/backend/boards/domain/TaskStatus.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/domain/TaskStatus.java
@@ -1,5 +1,7 @@
 package com.massimotter.weave.backend.boards.domain;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public enum TaskStatus {
     OPEN("open"),
     BLOCKED("blocked"),
@@ -12,6 +14,7 @@ public enum TaskStatus {
         this.contractName = contractName;
     }
 
+    @JsonValue
     public String contractName() {
         return contractName;
     }

--- a/src/main/java/com/massimotter/weave/backend/boards/local/LocalPreviewBoardsRepository.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/local/LocalPreviewBoardsRepository.java
@@ -1,0 +1,272 @@
+package com.massimotter.weave.backend.boards.local;
+
+import com.massimotter.weave.backend.boards.domain.Board;
+import com.massimotter.weave.backend.boards.domain.BoardCapability;
+import com.massimotter.weave.backend.boards.domain.BoardColumn;
+import com.massimotter.weave.backend.boards.domain.BoardProviderCapabilities;
+import com.massimotter.weave.backend.boards.domain.ColumnSemanticStatus;
+import com.massimotter.weave.backend.boards.domain.Label;
+import com.massimotter.weave.backend.boards.domain.ProjectVisibility;
+import com.massimotter.weave.backend.boards.domain.ProviderKind;
+import com.massimotter.weave.backend.boards.domain.ProviderRef;
+import com.massimotter.weave.backend.boards.domain.TaskAttachment;
+import com.massimotter.weave.backend.boards.domain.TaskComment;
+import com.massimotter.weave.backend.boards.domain.TaskItem;
+import com.massimotter.weave.backend.boards.domain.TaskPriority;
+import com.massimotter.weave.backend.boards.domain.TaskStatus;
+import com.massimotter.weave.backend.boards.domain.WeaveProject;
+import com.massimotter.weave.backend.boards.port.BoardPage;
+import com.massimotter.weave.backend.boards.port.BoardQuery;
+import com.massimotter.weave.backend.boards.port.BoardsRepository;
+import com.massimotter.weave.backend.boards.port.CreateTaskCommand;
+import com.massimotter.weave.backend.boards.port.MoveTaskCommand;
+import com.massimotter.weave.backend.boards.port.TaskQuery;
+import com.massimotter.weave.backend.boards.support.BoardsErrorCode;
+import com.massimotter.weave.backend.boards.support.BoardsException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Hidden local Boards/Tasks runtime slice used to prove the provider-neutral facade
+ * before a Vikunja/Deck/OpenProject adapter is promoted. It stores only preview
+ * fixture data in memory and never contacts or exposes upstream provider systems.
+ */
+public class LocalPreviewBoardsRepository implements BoardsRepository {
+
+    private static final String PROJECT_ID = "local-project-1";
+    private static final String BOARD_ID = "local-board-1";
+    private static final String TODO_COLUMN = "local-column-todo";
+    private static final String ACTIVE_COLUMN = "local-column-active";
+    private static final String BLOCKED_COLUMN = "local-column-blocked";
+    private static final String DONE_COLUMN = "local-column-done";
+
+    private final Instant seededAt;
+    private final Map<String, TaskItem> tasks = new ConcurrentHashMap<>();
+
+    public LocalPreviewBoardsRepository() {
+        this(Instant.parse("2026-05-14T18:00:00Z"));
+    }
+
+    LocalPreviewBoardsRepository(Instant seededAt) {
+        this.seededAt = seededAt;
+        seed();
+    }
+
+    @Override
+    public BoardProviderCapabilities capabilities() {
+        return new BoardProviderCapabilities(
+                ProviderKind.IN_MEMORY,
+                true,
+                Set.of(BoardCapability.ACCESSIBLE_NON_DRAG_MOVES),
+                Set.of(
+                        BoardCapability.COMMENTS,
+                        BoardCapability.ATTACHMENTS,
+                        BoardCapability.NON_DESTRUCTIVE_ARCHIVE,
+                        BoardCapability.WEBHOOK_EVENTS,
+                        BoardCapability.INCREMENTAL_SYNC,
+                        BoardCapability.CHECKLISTS,
+                        BoardCapability.CUSTOM_FIELDS),
+                "Hidden local preview facade: create, move, and complete tasks without drag-only interactions; no live provider adapter is enabled.");
+    }
+
+    @Override
+    public BoardPage<WeaveProject> listProjects(BoardQuery query) {
+        return BoardPage.singlePage(List.of(new WeaveProject(
+                PROJECT_ID,
+                "Weave workspace",
+                ProjectVisibility.WORKSPACE,
+                List.of("workspace:members"),
+                List.of())));
+    }
+
+    @Override
+    public BoardPage<Board> listBoards(String projectId, BoardQuery query) {
+        ensureProject(projectId);
+        return BoardPage.singlePage(List.of(board()));
+    }
+
+    @Override
+    public java.util.Optional<Board> findBoard(String boardId) {
+        return BOARD_ID.equals(boardId) ? java.util.Optional.of(board()) : java.util.Optional.empty();
+    }
+
+    @Override
+    public BoardPage<BoardColumn> listColumns(String boardId, BoardQuery query) {
+        ensureBoard(boardId);
+        return BoardPage.singlePage(columns());
+    }
+
+    @Override
+    public BoardPage<TaskItem> listTasks(String boardId, TaskQuery query) {
+        ensureBoard(boardId);
+        return BoardPage.singlePage(sortedTasks().stream()
+                .filter(task -> query == null || query.columnId() == null || query.columnId().equals(task.columnId()))
+                .toList());
+    }
+
+    @Override
+    public BoardPage<Label> listLabels(String boardId, BoardQuery query) {
+        ensureBoard(boardId);
+        return BoardPage.singlePage(List.of());
+    }
+
+    @Override
+    public BoardPage<TaskComment> listComments(String taskId, BoardQuery query) {
+        ensureTask(taskId);
+        return BoardPage.singlePage(List.of());
+    }
+
+    @Override
+    public BoardPage<TaskAttachment> listAttachments(String taskId, BoardQuery query) {
+        ensureTask(taskId);
+        return BoardPage.singlePage(List.of());
+    }
+
+    @Override
+    public TaskItem createTask(CreateTaskCommand command) {
+        ensureBoard(command.boardId());
+        ensureColumn(command.columnId());
+        Instant now = Instant.now();
+        String id = "local-task-" + UUID.randomUUID();
+        int nextPosition = (int) tasks.values().stream()
+                .filter(task -> command.columnId().equals(task.columnId()))
+                .count();
+        TaskItem task = new TaskItem(
+                id,
+                command.boardId(),
+                command.columnId(),
+                command.title(),
+                command.description(),
+                TaskStatus.OPEN,
+                nextPosition,
+                command.assigneeRefs(),
+                command.labelRefs(),
+                TaskPriority.NORMAL,
+                null,
+                command.dueAt(),
+                null,
+                now,
+                List.of());
+        tasks.put(id, task);
+        return task;
+    }
+
+    @Override
+    public TaskItem moveTask(MoveTaskCommand command) {
+        ensureColumn(command.targetColumnId());
+        TaskItem current = ensureTask(command.taskId());
+        TaskItem moved = current.moveTo(command.targetColumnId(), command.targetPosition(), Instant.now());
+        tasks.put(command.taskId(), moved);
+        return moved;
+    }
+
+    @Override
+    public TaskItem completeTask(String taskId) {
+        TaskItem current = ensureTask(taskId);
+        TaskItem completed = current.moveTo(DONE_COLUMN, current.position(), Instant.now()).complete(Instant.now());
+        tasks.put(taskId, completed);
+        return completed;
+    }
+
+    private Board board() {
+        return new Board(
+                BOARD_ID,
+                PROJECT_ID,
+                "Launch readiness board",
+                "Hidden provider-neutral preview fed by the backend facade, not by a static Flutter-only fixture.",
+                columns(),
+                false,
+                List.of());
+    }
+
+    private List<BoardColumn> columns() {
+        return List.of(
+                new BoardColumn(TODO_COLUMN, BOARD_ID, "To do", 0, ColumnSemanticStatus.NOT_STARTED, null, List.of()),
+                new BoardColumn(ACTIVE_COLUMN, BOARD_ID, "In progress", 1, ColumnSemanticStatus.IN_PROGRESS, 4, List.of()),
+                new BoardColumn(BLOCKED_COLUMN, BOARD_ID, "Blocked", 2, ColumnSemanticStatus.BLOCKED, null, List.of()),
+                new BoardColumn(DONE_COLUMN, BOARD_ID, "Done", 3, ColumnSemanticStatus.DONE, null, List.of()));
+    }
+
+    private List<TaskItem> sortedTasks() {
+        Map<String, Integer> columnOrder = new LinkedHashMap<>();
+        List<BoardColumn> columns = columns();
+        for (int i = 0; i < columns.size(); i++) {
+            columnOrder.put(columns.get(i).id(), i);
+        }
+        return tasks.values().stream()
+                .sorted(Comparator
+                        .comparing((TaskItem task) -> columnOrder.getOrDefault(task.columnId(), 99))
+                        .thenComparing(TaskItem::position)
+                        .thenComparing(TaskItem::title))
+                .toList();
+    }
+
+    private void seed() {
+        List<TaskItem> seedTasks = new ArrayList<>();
+        seedTasks.add(task("local-task-contract", TODO_COLUMN, "Review board API contract", "Keep routes hidden and provider-neutral before enabling a live adapter.", 0, TaskStatus.OPEN));
+        seedTasks.add(task("local-task-a11y", ACTIVE_COLUMN, "Validate non-drag movement", "Keyboard and screen-reader users need move and complete actions without pointer drag.", 0, TaskStatus.OPEN));
+        seedTasks.add(task("local-task-provider", BLOCKED_COLUMN, "Choose provider adapter", "Vikunja remains the first candidate; Deck and OpenProject stay evaluated behind the Weave model.", 0, TaskStatus.BLOCKED));
+        seedTasks.add(task("local-task-events", DONE_COLUMN, "Normalize task events", "Event envelopes redact provider details before later notifications or audits consume them.", 0, TaskStatus.COMPLETED));
+        seedTasks.forEach(task -> tasks.put(task.id(), task));
+    }
+
+    private TaskItem task(String id, String columnId, String title, String description, int position, TaskStatus status) {
+        return new TaskItem(
+                id,
+                BOARD_ID,
+                columnId,
+                title,
+                description,
+                status,
+                position,
+                List.of("workspace:member"),
+                List.of(),
+                TaskPriority.NORMAL,
+                null,
+                null,
+                status == TaskStatus.COMPLETED ? seededAt : null,
+                seededAt,
+                List.of(new ProviderRef(ProviderKind.IN_MEMORY, id, null, null, null, seededAt)));
+    }
+
+    private void ensureProject(String projectId) {
+        if (!PROJECT_ID.equals(projectId)) {
+            throw notFound("project");
+        }
+    }
+
+    private void ensureBoard(String boardId) {
+        if (!BOARD_ID.equals(boardId)) {
+            throw notFound("board");
+        }
+    }
+
+    private void ensureColumn(String columnId) {
+        boolean exists = columns().stream().anyMatch(column -> column.id().equals(columnId));
+        if (!exists) {
+            throw notFound("column");
+        }
+    }
+
+    private TaskItem ensureTask(String taskId) {
+        TaskItem task = tasks.get(taskId);
+        if (task == null) {
+            throw notFound("task");
+        }
+        return task;
+    }
+
+    private BoardsException notFound(String resource) {
+        return new BoardsException(
+                BoardsErrorCode.NOT_FOUND,
+                "Boards preview " + resource + " was not found.",
+                Map.of("resource", resource));
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/config/BoardsRuntimeConfiguration.java
+++ b/src/main/java/com/massimotter/weave/backend/config/BoardsRuntimeConfiguration.java
@@ -1,0 +1,23 @@
+package com.massimotter.weave.backend.config;
+
+import com.massimotter.weave.backend.boards.local.LocalPreviewBoardsRepository;
+import com.massimotter.weave.backend.boards.port.BoardsPreviewGuard;
+import com.massimotter.weave.backend.boards.port.BoardsRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class BoardsRuntimeConfiguration {
+
+    @Bean
+    BoardsPreviewGuard boardsPreviewGuard(
+            @Value("${weave.boards.preview.runtime-enabled:false}") boolean enabled) {
+        return new BoardsPreviewGuard(enabled);
+    }
+
+    @Bean
+    BoardsRepository boardsRepository() {
+        return new LocalPreviewBoardsRepository();
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/controller/BoardsController.java
+++ b/src/main/java/com/massimotter/weave/backend/controller/BoardsController.java
@@ -1,0 +1,80 @@
+package com.massimotter.weave.backend.controller;
+
+import com.massimotter.weave.backend.boards.domain.TaskItem;
+import com.massimotter.weave.backend.model.ApiErrorResponse;
+import com.massimotter.weave.backend.model.boards.BoardsCreateTaskRequest;
+import com.massimotter.weave.backend.model.boards.BoardsMoveTaskRequest;
+import com.massimotter.weave.backend.model.boards.BoardsPreviewResponse;
+import com.massimotter.weave.backend.service.BoardsFacadeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Validated
+@Tag(name = "Boards preview", description = "Hidden provider-neutral Boards/Tasks preview facade backed by a local in-memory adapter.")
+@SecurityRequirement(name = "bearer-jwt")
+@ApiResponses({
+        @ApiResponse(responseCode = "401", description = "Missing or invalid bearer token.",
+                content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+        @ApiResponse(responseCode = "403", description = "Bearer token is missing the weave:workspace scope.",
+                content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+        @ApiResponse(responseCode = "503", description = "Boards preview runtime is disabled or provider capability is unavailable.",
+                content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+})
+public class BoardsController {
+
+    private final BoardsFacadeService boardsFacadeService;
+
+    public BoardsController(BoardsFacadeService boardsFacadeService) {
+        this.boardsFacadeService = boardsFacadeService;
+    }
+
+    @GetMapping("/api/boards/preview")
+    @Operation(summary = "Read the hidden Boards/Tasks preview facade")
+    @ApiResponse(responseCode = "200", description = "Provider-neutral Boards/Tasks preview snapshot.",
+            content = @Content(schema = @Schema(implementation = BoardsPreviewResponse.class)))
+    public BoardsPreviewResponse preview() {
+        return boardsFacadeService.preview();
+    }
+
+    @PostMapping("/api/boards/{boardId}/tasks")
+    @Operation(summary = "Create a task in the hidden Boards/Tasks preview facade")
+    @ApiResponse(responseCode = "200", description = "Created provider-neutral task.",
+            content = @Content(schema = @Schema(implementation = TaskItem.class)))
+    public TaskItem createTask(
+            @PathVariable @Size(max = 128) String boardId,
+            @Valid @RequestBody BoardsCreateTaskRequest request) {
+        return boardsFacadeService.createTask(boardId, request);
+    }
+
+    @PostMapping("/api/boards/tasks/{taskId}/move")
+    @Operation(summary = "Move a task without drag-and-drop in the hidden Boards/Tasks preview facade")
+    @ApiResponse(responseCode = "200", description = "Moved provider-neutral task.",
+            content = @Content(schema = @Schema(implementation = TaskItem.class)))
+    public TaskItem moveTask(
+            @PathVariable @Size(max = 128) String taskId,
+            @Valid @RequestBody BoardsMoveTaskRequest request) {
+        return boardsFacadeService.moveTask(taskId, request);
+    }
+
+    @PostMapping("/api/boards/tasks/{taskId}/complete")
+    @Operation(summary = "Complete a task without drag-and-drop in the hidden Boards/Tasks preview facade")
+    @ApiResponse(responseCode = "200", description = "Completed provider-neutral task.",
+            content = @Content(schema = @Schema(implementation = TaskItem.class)))
+    public TaskItem completeTask(@PathVariable @Size(max = 128) String taskId) {
+        return boardsFacadeService.completeTask(taskId);
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/model/boards/BoardsCreateTaskRequest.java
+++ b/src/main/java/com/massimotter/weave/backend/model/boards/BoardsCreateTaskRequest.java
@@ -1,0 +1,15 @@
+package com.massimotter.weave.backend.model.boards;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+import java.util.List;
+
+public record BoardsCreateTaskRequest(
+        @NotBlank @Size(max = 128) String columnId,
+        @NotBlank @Size(max = 160) String title,
+        @Size(max = 2000) String description,
+        List<@Size(max = 128) String> assigneeRefs,
+        List<@Size(max = 128) String> labelRefs,
+        Instant dueAt) {
+}

--- a/src/main/java/com/massimotter/weave/backend/model/boards/BoardsMoveTaskRequest.java
+++ b/src/main/java/com/massimotter/weave/backend/model/boards/BoardsMoveTaskRequest.java
@@ -1,0 +1,10 @@
+package com.massimotter.weave.backend.model.boards;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record BoardsMoveTaskRequest(
+        @NotBlank @Size(max = 128) String targetColumnId,
+        @Min(0) int targetPosition) {
+}

--- a/src/main/java/com/massimotter/weave/backend/model/boards/BoardsPreviewResponse.java
+++ b/src/main/java/com/massimotter/weave/backend/model/boards/BoardsPreviewResponse.java
@@ -1,0 +1,23 @@
+package com.massimotter.weave.backend.model.boards;
+
+import com.massimotter.weave.backend.boards.domain.Board;
+import com.massimotter.weave.backend.boards.domain.BoardProviderCapabilities;
+import com.massimotter.weave.backend.boards.domain.TaskItem;
+import com.massimotter.weave.backend.boards.domain.WeaveProject;
+import java.util.List;
+
+public record BoardsPreviewResponse(
+        boolean preview,
+        String releaseStatus,
+        String source,
+        BoardProviderCapabilities capabilities,
+        List<WeaveProject> projects,
+        List<Board> boards,
+        List<TaskItem> tasks) {
+
+    public BoardsPreviewResponse {
+        projects = List.copyOf(projects);
+        boards = List.copyOf(boards);
+        tasks = List.copyOf(tasks);
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/service/BoardsFacadeService.java
+++ b/src/main/java/com/massimotter/weave/backend/service/BoardsFacadeService.java
@@ -1,0 +1,118 @@
+package com.massimotter.weave.backend.service;
+
+import com.massimotter.weave.backend.boards.domain.TaskItem;
+import com.massimotter.weave.backend.boards.port.BoardQuery;
+import com.massimotter.weave.backend.boards.port.BoardsPreviewGuard;
+import com.massimotter.weave.backend.boards.port.BoardsRepository;
+import com.massimotter.weave.backend.boards.port.CreateTaskCommand;
+import com.massimotter.weave.backend.boards.port.MoveTaskCommand;
+import com.massimotter.weave.backend.boards.port.TaskQuery;
+import com.massimotter.weave.backend.boards.support.BoardsErrorCode;
+import com.massimotter.weave.backend.boards.support.BoardsException;
+import com.massimotter.weave.backend.exception.ApiErrorException;
+import com.massimotter.weave.backend.model.boards.BoardsCreateTaskRequest;
+import com.massimotter.weave.backend.model.boards.BoardsMoveTaskRequest;
+import com.massimotter.weave.backend.model.boards.BoardsPreviewResponse;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BoardsFacadeService {
+
+    private final BoardsPreviewGuard previewGuard;
+    private final BoardsRepository boardsRepository;
+
+    public BoardsFacadeService(BoardsPreviewGuard previewGuard, BoardsRepository boardsRepository) {
+        this.previewGuard = previewGuard;
+        this.boardsRepository = boardsRepository;
+    }
+
+    public BoardsPreviewResponse preview() {
+        requireEnabled();
+        try {
+            var projects = boardsRepository.listProjects(BoardQuery.firstPage()).items();
+            var boards = projects.stream()
+                    .flatMap(project -> boardsRepository.listBoards(project.id(), BoardQuery.firstPage()).items().stream())
+                    .toList();
+            var tasks = boards.stream()
+                    .flatMap(board -> boardsRepository.listTasks(board.id(), TaskQuery.all()).items().stream())
+                    .toList();
+            return new BoardsPreviewResponse(
+                    true,
+                    "post-release-hidden-preview",
+                    "local-preview-backend-facade",
+                    boardsRepository.capabilities(),
+                    projects,
+                    boards,
+                    tasks);
+        } catch (BoardsException exception) {
+            throw apiError(exception);
+        }
+    }
+
+    public TaskItem createTask(String boardId, BoardsCreateTaskRequest request) {
+        requireEnabled();
+        try {
+            return boardsRepository.createTask(new CreateTaskCommand(
+                    boardId,
+                    request.columnId(),
+                    request.title(),
+                    request.description(),
+                    request.assigneeRefs(),
+                    request.labelRefs(),
+                    request.dueAt()));
+        } catch (BoardsException exception) {
+            throw apiError(exception);
+        }
+    }
+
+    public TaskItem moveTask(String taskId, BoardsMoveTaskRequest request) {
+        requireEnabled();
+        try {
+            return boardsRepository.moveTask(new MoveTaskCommand(
+                    taskId,
+                    request.targetColumnId(),
+                    request.targetPosition()));
+        } catch (BoardsException exception) {
+            throw apiError(exception);
+        }
+    }
+
+    public TaskItem completeTask(String taskId) {
+        requireEnabled();
+        try {
+            return boardsRepository.completeTask(taskId);
+        } catch (BoardsException exception) {
+            throw apiError(exception);
+        }
+    }
+
+    private void requireEnabled() {
+        try {
+            previewGuard.requireEnabled();
+        } catch (BoardsException exception) {
+            throw apiError(exception);
+        }
+    }
+
+    private ApiErrorException apiError(BoardsException exception) {
+        HttpStatus status = switch (exception.code()) {
+            case UNAUTHORIZED -> HttpStatus.UNAUTHORIZED;
+            case FORBIDDEN -> HttpStatus.FORBIDDEN;
+            case NOT_FOUND -> HttpStatus.NOT_FOUND;
+            case CONFLICT -> HttpStatus.CONFLICT;
+            case RATE_LIMITED -> HttpStatus.TOO_MANY_REQUESTS;
+            case VALIDATION -> HttpStatus.BAD_REQUEST;
+            case PROVIDER_UNAVAILABLE, OFFLINE, UNSUPPORTED_CAPABILITY -> HttpStatus.SERVICE_UNAVAILABLE;
+            case UNKNOWN -> HttpStatus.INTERNAL_SERVER_ERROR;
+        };
+        Map<String, Object> details = new LinkedHashMap<>();
+        details.put("module", "boards");
+        details.put("preview", true);
+        details.put("releaseStatus", "post-release-hidden-preview");
+        details.putAll(exception.details());
+        return new ApiErrorException(status, "boards-" + exception.code().contractName(), exception.getMessage(), details);
+    }
+}

--- a/src/main/resources/contracts/boards-preview.openapi.yaml
+++ b/src/main/resources/contracts/boards-preview.openapi.yaml
@@ -4,12 +4,147 @@ info:
   version: preview
   description: >-
     Preview-only provider-neutral schema components for future Boards/Tasks work.
-    This document intentionally declares no paths: the module is hidden, disabled
-    for Release 1, and not a published product API until a later promotion spec
-    defines routes, auth scopes, status codes, smoke/E2E, and accessibility gates.
-paths: {}
+    Hidden preview-only provider-neutral schema and route draft for future Boards/Tasks work.
+    The runtime routes are disabled by default, require the normal authenticated Weave
+    workspace boundary, use only a local/in-memory preview adapter, and do not publish
+    Boards/Tasks as a Release 1 product API.
+paths:
+  /api/boards/preview:
+    get:
+      summary: Read hidden Boards/Tasks preview snapshot
+      responses:
+        '200':
+          description: Provider-neutral hidden preview snapshot.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BoardsPreviewResponse'
+        '401': { description: Missing or invalid bearer token. }
+        '403': { description: Missing weave:workspace scope. }
+        '503': { description: Preview runtime is disabled or unavailable. }
+  /api/boards/{boardId}/tasks:
+    post:
+      summary: Create a hidden preview task
+      parameters:
+        - name: boardId
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BoardsCreateTaskRequest'
+      responses:
+        '200':
+          description: Created provider-neutral task.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskItem'
+  /api/boards/tasks/{taskId}/move:
+    post:
+      summary: Move a hidden preview task without drag-and-drop
+      parameters:
+        - name: taskId
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BoardsMoveTaskRequest'
+      responses:
+        '200':
+          description: Moved provider-neutral task.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskItem'
+  /api/boards/tasks/{taskId}/complete:
+    post:
+      summary: Complete a hidden preview task without drag-and-drop
+      parameters:
+        - name: taskId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Completed provider-neutral task.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskItem'
+
 components:
   schemas:
+
+    BoardsPreviewResponse:
+      type: object
+      required: [preview, releaseStatus, source, capabilities, projects, boards, tasks]
+      properties:
+        preview: { type: boolean }
+        releaseStatus:
+          type: string
+          enum: [post-release-hidden-preview]
+        source:
+          type: string
+          enum: [local-preview-backend-facade]
+        capabilities:
+          $ref: '#/components/schemas/BoardProviderCapabilities'
+        projects:
+          type: array
+          items: { $ref: '#/components/schemas/WeaveProject' }
+        boards:
+          type: array
+          items: { $ref: '#/components/schemas/Board' }
+        tasks:
+          type: array
+          items: { $ref: '#/components/schemas/TaskItem' }
+    BoardProviderCapabilities:
+      type: object
+      required: [provider, enabled, supported, unsupported, supportSafeSummary]
+      properties:
+        provider:
+          type: string
+          enum: [vikunja, openproject, nextcloud-deck, in-memory, unknown]
+        enabled: { type: boolean }
+        supported:
+          type: array
+          items:
+            type: string
+            enum: [comments, attachments, non_destructive_archive, webhook_events, incremental_sync, checklists, custom_fields, accessible_non_drag_moves]
+        unsupported:
+          type: array
+          items:
+            type: string
+            enum: [comments, attachments, non_destructive_archive, webhook_events, incremental_sync, checklists, custom_fields, accessible_non_drag_moves]
+        supportSafeSummary: { type: string }
+    BoardsCreateTaskRequest:
+      type: object
+      required: [columnId, title]
+      properties:
+        columnId: { type: string, maxLength: 128 }
+        title: { type: string, maxLength: 160 }
+        description: { type: string, maxLength: 2000 }
+        assigneeRefs:
+          type: array
+          items: { type: string, maxLength: 128 }
+        labelRefs:
+          type: array
+          items: { type: string, maxLength: 128 }
+        dueAt: { type: string, format: date-time }
+    BoardsMoveTaskRequest:
+      type: object
+      required: [targetColumnId, targetPosition]
+      properties:
+        targetColumnId: { type: string, maxLength: 128 }
+        targetPosition: { type: integer, minimum: 0 }
+
     ProviderRef:
       type: object
       required: [provider, externalId]

--- a/src/test/java/com/massimotter/weave/backend/boards/BoardsPreviewContractTest.java
+++ b/src/test/java/com/massimotter/weave/backend/boards/BoardsPreviewContractTest.java
@@ -128,11 +128,13 @@ class BoardsPreviewContractTest {
     }
 
     @Test
-    void previewOpenApiContractDeclaresNoRoutes() throws Exception {
+    void previewOpenApiContractDeclaresHiddenLocalRoutesOnly() throws Exception {
         String contract = Files.readString(Path.of("src/main/resources/contracts/boards-preview.openapi.yaml"));
 
         assertThat(contract).contains("title: Weave Boards/Tasks Preview Contract");
-        assertThat(contract).contains("paths: {}");
+        assertThat(contract).contains("/api/boards/preview");
+        assertThat(contract).contains("/api/boards/{boardId}/tasks");
+        assertThat(contract).contains("post-release-hidden-preview");
         assertThat(contract).contains("TaskBoardEvent");
         assertThat(contract).contains("task.moved");
     }

--- a/src/test/java/com/massimotter/weave/backend/controller/BoardsControllerTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/BoardsControllerTest.java
@@ -1,0 +1,138 @@
+package com.massimotter.weave.backend.controller;
+
+import com.massimotter.weave.backend.config.ApiAccessDeniedHandler;
+import com.massimotter.weave.backend.config.ApiAuthenticationEntryPoint;
+import com.massimotter.weave.backend.config.ApiErrorResponseWriter;
+import com.massimotter.weave.backend.config.BoardsRuntimeConfiguration;
+import com.massimotter.weave.backend.config.SecurityConfig;
+import com.massimotter.weave.backend.exception.ApiExceptionHandler;
+import com.massimotter.weave.backend.service.BoardsFacadeService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = BoardsController.class,
+        excludeAutoConfiguration = OAuth2ResourceServerAutoConfiguration.class)
+@Import({
+        SecurityConfig.class,
+        ApiAuthenticationEntryPoint.class,
+        ApiAccessDeniedHandler.class,
+        ApiErrorResponseWriter.class,
+        ApiExceptionHandler.class,
+        BoardsRuntimeConfiguration.class,
+        BoardsFacadeService.class
+})
+@TestPropertySource(properties = {
+        "spring.security.oauth2.resourceserver.jwt.issuer-uri=https://auth.example.invalid/realms/weave",
+        "weave.boards.preview.runtime-enabled=true"
+})
+class BoardsControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JwtDecoder jwtDecoder;
+
+    @Test
+    void boardsPreviewRequiresAuthenticatedWorkspaceScope() throws Exception {
+        mockMvc.perform(get("/api/boards/preview"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("unauthorized"));
+    }
+
+    @Test
+    void boardsPreviewReturnsProviderNeutralLocalFacadeSnapshot() throws Exception {
+        mockMvc.perform(get("/api/boards/preview")
+                        .with(workspaceJwt()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.preview").value(true))
+                .andExpect(jsonPath("$.releaseStatus").value("post-release-hidden-preview"))
+                .andExpect(jsonPath("$.source").value("local-preview-backend-facade"))
+                .andExpect(jsonPath("$.capabilities.enabled").value(true))
+                .andExpect(jsonPath("$.projects[0].id").value("local-project-1"))
+                .andExpect(jsonPath("$.boards[0].id").value("local-board-1"))
+                .andExpect(jsonPath("$.boards[0].columns[0].semanticStatus").value("not_started"))
+                .andExpect(jsonPath("$.tasks.length()").value(greaterThanOrEqualTo(4)))
+                .andExpect(jsonPath("$.tasks[0].providerRefs[0].provider").value("in-memory"));
+    }
+
+    @Test
+    void boardsPreviewSupportsCreateMoveAndCompleteWithoutDragOnlyFlow() throws Exception {
+        String createPayload = """
+                {
+                  "columnId": "local-column-todo",
+                  "title": "Write acceptance evidence",
+                  "description": "Created through the backend Boards preview facade.",
+                  "assigneeRefs": ["workspace:member"],
+                  "labelRefs": ["evidence"]
+                }
+                """;
+
+        String response = mockMvc.perform(post("/api/boards/local-board-1/tasks")
+                        .with(workspaceJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(createPayload))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.boardId").value("local-board-1"))
+                .andExpect(jsonPath("$.columnId").value("local-column-todo"))
+                .andExpect(jsonPath("$.title").value("Write acceptance evidence"))
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        String taskId = com.jayway.jsonpath.JsonPath.read(response, "$.id");
+
+        mockMvc.perform(post("/api/boards/tasks/{taskId}/move", taskId)
+                        .with(workspaceJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"targetColumnId\":\"local-column-active\",\"targetPosition\":0}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(taskId))
+                .andExpect(jsonPath("$.columnId").value("local-column-active"));
+
+        mockMvc.perform(post("/api/boards/tasks/{taskId}/complete", taskId)
+                        .with(workspaceJwt()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(taskId))
+                .andExpect(jsonPath("$.columnId").value("local-column-done"))
+                .andExpect(jsonPath("$.status").value("completed"))
+                .andExpect(jsonPath("$.completedAt").exists());
+    }
+
+    @Test
+    void boardsPreviewUsesSupportSafeErrorsForUnknownTasks() throws Exception {
+        mockMvc.perform(post("/api/boards/tasks/missing-task/complete")
+                        .with(workspaceJwt()))
+                .andExpect(status().isNotFound())
+                .andExpect(header().exists("X-Request-Id"))
+                .andExpect(jsonPath("$.code").value("boards-not_found"))
+                .andExpect(jsonPath("$.details.module").value("boards"))
+                .andExpect(jsonPath("$.details.preview").value(true))
+                .andExpect(jsonPath("$.details.resource").value("task"));
+    }
+
+    private org.springframework.test.web.servlet.request.RequestPostProcessor workspaceJwt() {
+        return jwt().jwt(jwt -> jwt
+                        .subject("user-123")
+                        .claim("aud", java.util.List.of("weave-app")))
+                .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"));
+    }
+}

--- a/src/test/java/com/massimotter/weave/backend/service/BoardsFacadeServiceTest.java
+++ b/src/test/java/com/massimotter/weave/backend/service/BoardsFacadeServiceTest.java
@@ -1,0 +1,28 @@
+package com.massimotter.weave.backend.service;
+
+import com.massimotter.weave.backend.boards.local.LocalPreviewBoardsRepository;
+import com.massimotter.weave.backend.boards.port.BoardsPreviewGuard;
+import com.massimotter.weave.backend.exception.ApiErrorException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class BoardsFacadeServiceTest {
+
+    @Test
+    void previewRuntimeFailsClosedWhenFeatureFlagIsDisabled() {
+        BoardsFacadeService service = new BoardsFacadeService(
+                new BoardsPreviewGuard(false),
+                new LocalPreviewBoardsRepository());
+
+        assertThatThrownBy(service::preview)
+                .isInstanceOfSatisfying(ApiErrorException.class, error -> {
+                    assertThat(error.status().value()).isEqualTo(503);
+                    assertThat(error.code()).isEqualTo("boards-provider_unavailable");
+                    assertThat(error.details()).containsEntry("module", "boards");
+                    assertThat(error.details()).containsEntry("preview", true);
+                    assertThat(error.details()).containsEntry("releaseStatus", "post-release-hidden-preview");
+                });
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a hidden, authenticated Boards/Tasks preview runtime facade behind `weave.boards.preview.runtime-enabled=false` by default.
- Uses a local in-memory provider-neutral adapter only; no Vikunja/Deck/OpenProject runtime, secrets, provider URLs, or Release 1 product enablement.
- Adds create, move, and complete routes for non-drag task flows plus support-safe `boards-*` errors and OpenAPI/docs updates.

## Issue/spec matrix
| Track | Source | Outcome |
| --- | --- | --- |
| Boards/Tasks runtime | `specs/14-boards-tasks-domain-and-provider-adapter-contract.md`; weave #119-#123 | Implemented hidden local backend facade and contract tests. |
| Calendar private/workspace model | weave-backend #52 | Deferred: existing workspace calendar facade remains; private CalDAV stays fail-closed. |
| Calendar external credentials/profile | weave-backend #56; weave-infra #54 | Deferred: no credential/profile issuing until revocation, storage, redaction, and support-bundle handling are solved. |

## Acceptance evidence
- Runtime disabled by default and fails closed with `boards-provider_unavailable`.
- Routes require the normal authenticated `weave:workspace` boundary.
- Responses use provider-neutral Weave domain DTOs and `releaseStatus=post-release-hidden-preview`.
- Local adapter stores only in-memory preview data and exposes no raw provider secrets/URLs/errors.

## Validation
- `./gradlew compileJava`
- `./gradlew test --tests com.massimotter.weave.backend.controller.BoardsControllerTest`
- `./gradlew test --tests com.massimotter.weave.backend.service.BoardsFacadeServiceTest`
- `./gradlew test --tests com.massimotter.weave.backend.boards.BoardsPreviewContractTest`
- `./gradlew test`
- `git diff --check`

## Follow-up
- Merge the Flutter consumer PR after/with this backend contract PR.
- Calendar #52/#56 and infra #54 need a separate security-focused wave; this PR deliberately does not fake those flows.
