### PR TITLE
feat(calendar): add event read facade endpoint

### DIFF
--- a/src/main/java/com/massimotter/weave/backend/controller/CalendarController.java
+++ b/src/main/java/com/massimotter/weave/backend/controller/CalendarController.java
@@ -128,6 +128,14 @@ public class CalendarController {
         return calendarFacadeService.create(request);
     }
 
+    @GetMapping("/api/calendar/events/{id}")
+    @Operation(summary = "Read a calendar event")
+    @ApiResponse(responseCode = "200", description = "Calendar event.",
+            content = @Content(schema = @Schema(implementation = CalendarEventResponse.class)))
+    public CalendarEventResponse read(@PathVariable @Size(max = 2048) String id) {
+        return calendarFacadeService.read(id);
+    }
+
     @PatchMapping("/api/calendar/events/{id}")
     @Operation(summary = "Update a calendar event")
     @ApiResponse(responseCode = "200", description = "Updated calendar event.",

--- a/src/main/java/com/massimotter/weave/backend/service/CalendarFacadeService.java
+++ b/src/main/java/com/massimotter/weave/backend/service/CalendarFacadeService.java
@@ -78,6 +78,14 @@ public class CalendarFacadeService {
         }
     }
 
+    public CalendarEventResponse read(String id) {
+        try {
+            return adapter("read-event").read(principal(), id);
+        } catch (CalendarAdapterException exception) {
+            throw apiError(exception, "read-event");
+        }
+    }
+
     public CalendarEventResponse update(String id, UpdateCalendarEventRequest request) {
         try {
             return adapter("update-event").update(principal(), id, request);

--- a/src/main/java/com/massimotter/weave/backend/service/calendar/CalDavCalendarAdapter.java
+++ b/src/main/java/com/massimotter/weave/backend/service/calendar/CalDavCalendarAdapter.java
@@ -96,17 +96,19 @@ public class CalDavCalendarAdapter implements CalendarAdapter {
     }
 
     @Override
+    public CalendarEventResponse read(CalendarPrincipal principal, String id) {
+        ensureConfigured("read-event");
+        String href = hrefFromOpaqueId(id, principal);
+        HttpResponse<String> existing = getEvent(href, "read-event");
+        return mapper.toResponse(id, existing.headers().firstValue("ETag").orElse(null), existing.body());
+    }
+
+    @Override
     public CalendarEventResponse update(CalendarPrincipal principal, String id, UpdateCalendarEventRequest request) {
         ensureConfigured("update-event");
         String href = hrefFromOpaqueId(id, principal);
         URI eventUri = eventUri(href);
-        HttpResponse<String> existing = send(requestBuilder(eventUri)
-                .GET()
-                .header("Accept", "text/calendar")
-                .build(), "update-event");
-        if (!isSuccess(existing.statusCode())) {
-            throw mapStatus(existing.statusCode(), "update-event", href);
-        }
+        HttpResponse<String> existing = getEvent(href, "update-event");
 
         IcalendarMapper.EventDraft merged = mapper.merge(mapper.parse(existing.body()), request);
         HttpRequest.Builder builder = requestBuilder(eventUri)
@@ -222,6 +224,17 @@ public class CalDavCalendarAdapter implements CalendarAdapter {
                     .encodeToString(credentials.getBytes(StandardCharsets.UTF_8)));
         }
         return builder;
+    }
+
+    private HttpResponse<String> getEvent(String href, String operation) {
+        HttpResponse<String> existing = send(requestBuilder(eventUri(href))
+                .GET()
+                .header("Accept", "text/calendar")
+                .build(), operation);
+        if (!isSuccess(existing.statusCode())) {
+            throw mapStatus(existing.statusCode(), operation, href);
+        }
+        return existing;
     }
 
     private HttpResponse<String> send(HttpRequest request, String operation) {

--- a/src/main/java/com/massimotter/weave/backend/service/calendar/CalendarAdapter.java
+++ b/src/main/java/com/massimotter/weave/backend/service/calendar/CalendarAdapter.java
@@ -14,6 +14,8 @@ public interface CalendarAdapter {
     CalendarEventResponse create(CalendarPrincipal principal, CreateCalendarEventRequest request)
             throws CalendarAdapterException;
 
+    CalendarEventResponse read(CalendarPrincipal principal, String id) throws CalendarAdapterException;
+
     CalendarEventResponse update(CalendarPrincipal principal, String id, UpdateCalendarEventRequest request)
             throws CalendarAdapterException;
 

--- a/src/test/java/com/massimotter/weave/backend/controller/FilesCalendarFacadeControllerTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/FilesCalendarFacadeControllerTest.java
@@ -90,6 +90,17 @@ class FilesCalendarFacadeControllerTest {
     }
 
     @Test
+    void calendarReadFacadeExposesStableUnavailableErrorUntilNextcloudAdapterExists() throws Exception {
+        mockMvc.perform(get("/api/calendar/events/event-id")
+                        .with(workspaceJwt()))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(header().exists("X-Request-Id"))
+                .andExpect(jsonPath("$.code").value("nextcloud-adapter-not-configured"))
+                .andExpect(jsonPath("$.details.module").value("calendar"))
+                .andExpect(jsonPath("$.details.operation").value("read-event"));
+    }
+
+    @Test
     void calendarClientSetupExposesSecretFreePlatformOptionsWithoutAdapterCredentials() throws Exception {
         mockMvc.perform(get("/api/calendar/client-setup")
                         .with(workspaceJwt()))

--- a/src/test/java/com/massimotter/weave/backend/controller/OpenApiDocumentationTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/OpenApiDocumentationTest.java
@@ -53,6 +53,7 @@ class OpenApiDocumentationTest {
                 .andExpect(jsonPath("$.paths['/api/calendar/client-setup/credentials/{credentialId}']").exists())
                 .andExpect(jsonPath("$.paths['/api/calendar/client-setup/apple.mobileconfig']").exists())
                 .andExpect(jsonPath("$.paths['/api/calendar/events/{id}']").exists())
+                .andExpect(jsonPath("$.paths['/api/calendar/events/{id}'].get").exists())
                 .andExpect(jsonPath("$.paths['/api/workspace/capabilities']").exists())
                 .andExpect(jsonPath("$.paths['/api/workspace/release-readiness']").exists())
                 .andExpect(jsonPath("$.paths['/api/v1/workspace/capabilities']").exists())

--- a/src/test/java/com/massimotter/weave/backend/service/CalendarFacadeServiceTest.java
+++ b/src/test/java/com/massimotter/weave/backend/service/CalendarFacadeServiceTest.java
@@ -62,6 +62,58 @@ class CalendarFacadeServiceTest {
     }
 
     @Test
+    void delegatesReadToAdapterWithWorkspaceScope() {
+        AtomicReference<CalendarPrincipal> capturedPrincipal = new AtomicReference<>();
+        CalendarEventResponse event = new CalendarEventResponse(
+                "event-id",
+                "Planning",
+                null,
+                OffsetDateTime.parse("2026-04-26T10:00:00+02:00"),
+                OffsetDateTime.parse("2026-04-26T11:00:00+02:00"),
+                "Europe/Berlin",
+                null,
+                false,
+                "etag");
+        CalendarAdapter adapter = new StubCalendarAdapter() {
+            @Override
+            public CalendarEventResponse read(CalendarPrincipal principal, String id) {
+                capturedPrincipal.set(principal);
+                assertThat(id).isEqualTo("event-id");
+                return event;
+            }
+        };
+        SecurityContextHolder.getContext().setAuthentication(new TestingAuthenticationToken(jwt(), null));
+
+        var response = service(adapter).read("event-id");
+
+        assertThat(response.scope().type()).isEqualTo("workspace");
+        assertThat(response.title()).isEqualTo("Planning");
+        assertThat(capturedPrincipal.get().subject()).isEqualTo("user-123");
+        assertThat(capturedPrincipal.get().nextcloudUserId()).isEqualTo("massimo");
+    }
+
+    @Test
+    void mapsReadNotFoundToStableApiError() {
+        CalendarAdapter adapter = new StubCalendarAdapter() {
+            @Override
+            public CalendarEventResponse read(CalendarPrincipal principal, String id) {
+                throw new CalendarAdapterException(CalendarAdapterException.Type.NOT_FOUND, "missing");
+            }
+        };
+        SecurityContextHolder.getContext().setAuthentication(new TestingAuthenticationToken(jwt(), null));
+
+        assertThatThrownBy(() -> service(adapter).read("missing-event"))
+                .isInstanceOf(ApiErrorException.class)
+                .satisfies(error -> {
+                    ApiErrorException apiError = (ApiErrorException) error;
+                    assertThat(apiError.status().value()).isEqualTo(404);
+                    assertThat(apiError.code()).isEqualTo("calendar-event-not-found");
+                    assertThat(apiError.details()).containsEntry("module", "calendar");
+                    assertThat(apiError.details()).containsEntry("operation", "read-event");
+                });
+    }
+
+    @Test
     void mapsAdapterConflictToStableApiError() {
         CalendarAdapter adapter = new StubCalendarAdapter() {
             @Override
@@ -113,6 +165,11 @@ class CalendarFacadeServiceTest {
         @Override
         public CalendarEventResponse create(CalendarPrincipal principal, CreateCalendarEventRequest request) {
             throw new AssertionError("unexpected create call");
+        }
+
+        @Override
+        public CalendarEventResponse read(CalendarPrincipal principal, String id) {
+            throw new AssertionError("unexpected read call");
         }
 
         @Override

--- a/src/test/java/com/massimotter/weave/backend/service/calendar/CalDavCalendarAdapterTest.java
+++ b/src/test/java/com/massimotter/weave/backend/service/calendar/CalDavCalendarAdapterTest.java
@@ -119,7 +119,7 @@ END:VCALENDAR&#13;
                         SUMMARY:Planning
                         END:VEVENT
                         END:VCALENDAR
-                        """, null);
+                        """, "\"etag-existing\"");
             } else if ("PUT".equals(exchange.getRequestMethod())) {
                 respond(exchange, 201, "", "\"etag-new\"");
             } else if ("DELETE".equals(exchange.getRequestMethod())) {
@@ -138,13 +138,17 @@ END:VCALENDAR&#13;
                 "Europe/Berlin",
                 null,
                 false));
+        var read = adapter.read(principal(), created.id());
         var updated = adapter.update(principal(), created.id(), new UpdateCalendarEventRequest(
                 "Updated", null, null, null, null, null, null, created.etag()));
         adapter.delete(principal(), created.id());
 
-        assertThat(methods).containsExactly("PUT", "GET", "PUT", "DELETE");
+        assertThat(methods).containsExactly("PUT", "GET", "GET", "PUT", "DELETE");
         assertThat(requestBodies.get(0)).contains("SUMMARY:Planning");
-        assertThat(requestBodies.get(2)).contains("SUMMARY:Updated");
+        assertThat(requestBodies.get(3)).contains("SUMMARY:Updated");
+        assertThat(read.title()).isEqualTo("Planning");
+        assertThat(read.etag()).isEqualTo("\"etag-existing\"");
+        assertThat(read.scope().type()).isEqualTo("workspace");
         assertThat(updated.title()).isEqualTo("Updated");
     }
 


### PR DESCRIPTION
## Summary

Adds the missing authenticated Calendar event read endpoint for the Release 2 workspace-calendar facade slice.

## Changes

- Adds `GET /api/calendar/events/{id}` to the Calendar controller/service contract.
- Extends the Calendar adapter boundary with `read(...)` and implements CalDAV GET-by-opaque-id.
- Reuses stable Calendar error mapping for read not-found/unavailable cases.
- Adds service, CalDAV adapter, controller unavailable-state, and OpenAPI coverage.

## Contract notes

- Event reads remain workspace-scoped through the existing `CalendarEventResponse.scope` metadata.
- Private per-user CalDAV templates remain fail-closed; this PR does not change the private calendar access model.
- No credentials, app passwords, bearer tokens, or backend actor secrets are returned.

## Validation

- `./gradlew test` ✅
- `./gradlew check` ✅

Refs masssi164/weave-backend#63