### PR TITLE
Prove Slack one-channel on-ramp

### DIFF
--- a/docs/runtime-configuration.md
+++ b/docs/runtime-configuration.md
@@ -78,3 +78,24 @@ When required actor credentials are missing or an unsafe private-user template i
 Profile facade endpoints are protected by the same first-party bearer-token contract as `/api/me`. `PATCH /api/profile` accepts partial updates for `displayName`, `avatar`, `locale`, `timezone`, `accessibilityPreferences`, and `profileVisibility`. Set `WEAVE_PROFILE_STORAGE_PATH` to mounted durable storage for containerized Release 1 runs.
 
 Onboarding status returns identity, roles, groups, invite status, profile completeness, and module provisioning states. Downstream states must remain frontend-safe and must not expose stack traces, tokens, secrets, or raw service errors.
+
+## Interop gateway, Slack on-ramp, guests, and migration previews
+
+Release 1 keeps interop, guest access, and migration/import execution disabled by default. The backend exposes contract/readiness surfaces so Release 2 work can be validated without making Slack, Teams, guest portal, connector SDK, or migration runtime behavior a Release 1 dependency.
+
+- `WEAVE_INTEROP_ENABLED`: master interop gateway flag, defaults to `false`.
+- `WEAVE_INTEROP_SUPPORT_BUNDLE_REDACTION_MODE`: support bundle redaction mode label, defaults to `support-safe-redacted`.
+- `WEAVE_INTEROP_SLACK_ENABLED`: Slack provider flag, defaults to `false`.
+- `WEAVE_INTEROP_SLACK_CLIENT_ID`: Slack app client id metadata. This is not secret material.
+- `WEAVE_INTEROP_SLACK_CLIENT_SECRET_REF`: reference to Slack OAuth client secret in an operator-owned secret store. Raw client secrets must not be supplied through API payloads or support bundles.
+- `WEAVE_INTEROP_SLACK_SIGNING_SECRET_REF`: reference to Slack request signing secret. Signed inbound events fail closed when this reference cannot be resolved by backend secret brokering.
+- `WEAVE_INTEROP_SLACK_TOKEN_REF`: reference to Slack bot token. Raw bot/access/refresh tokens must not be supplied through API payloads or support bundles.
+- `WEAVE_INTEROP_SLACK_WORKSPACE_ID`: one Slack workspace id for the proof-of-on-ramp.
+- `WEAVE_INTEROP_SLACK_CHANNEL_ID`: one Slack channel id mapped by the proof-of-on-ramp.
+- `WEAVE_INTEROP_SLACK_ROOM_ID`: one Weave/Matrix room reference mapped by the proof-of-on-ramp.
+- `WEAVE_INTEROP_TEAMS_ENABLED`: Teams provider flag, defaults to `false`; Teams remains gated behind Slack hardening.
+- `WEAVE_GUEST_ENABLED`: guest invitation flag, defaults to `false` and denies access while preserving distinct guest identity semantics.
+- `WEAVE_MIGRATION_ENABLED`: migration dry-run flag, defaults to `false`; dry-run reports are replay-safe and do not import source data.
+- `WEAVE_CONNECTORS_PUBLIC_SDK_ENABLED`: connector SDK flag, defaults to `false`; manifest validation rejects inline secret material.
+
+The Slack on-ramp is intentionally one-channel and sandbox-first. Inbound Slack text events require Slack HMAC request signature verification before mapping. Bot-message subtype events are rejected before mapping to prevent loops. Outbound Weave-to-Slack messages currently return a deterministic, idempotent `sandbox-not-delivered` response and do not call Slack production APIs. Status responses expose degraded/rate-limited/signature/loop-prevention reasons without exposing secret refs or raw provider tokens.

--- a/src/main/java/com/massimotter/weave/backend/controller/InteropController.java
+++ b/src/main/java/com/massimotter/weave/backend/controller/InteropController.java
@@ -1,10 +1,13 @@
 package com.massimotter.weave.backend.controller;
 
 import com.massimotter.weave.backend.model.ApiErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.massimotter.weave.backend.model.interop.CanonicalBridgeEventResponse;
 import com.massimotter.weave.backend.model.interop.InteropStatusResponse;
 import com.massimotter.weave.backend.model.interop.SlackEventRequest;
 import com.massimotter.weave.backend.model.interop.SlackOAuthCallbackRequest;
+import com.massimotter.weave.backend.model.interop.SlackOutboundMessageRequest;
+import com.massimotter.weave.backend.model.interop.SlackOutboundMessageResponse;
 import com.massimotter.weave.backend.model.interop.SlackStatusResponse;
 import com.massimotter.weave.backend.model.interop.TeamsContractResponse;
 import com.massimotter.weave.backend.service.interop.InteropGatewayService;
@@ -20,6 +23,7 @@ import java.util.Map;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -34,9 +38,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class InteropController {
 
     private final InteropGatewayService interopGatewayService;
+    private final ObjectMapper objectMapper;
 
-    public InteropController(InteropGatewayService interopGatewayService) {
+    public InteropController(InteropGatewayService interopGatewayService, ObjectMapper objectMapper) {
         this.interopGatewayService = interopGatewayService;
+        this.objectMapper = objectMapper;
     }
 
     @GetMapping("/api/interop/status")
@@ -63,8 +69,21 @@ public class InteropController {
     @Operation(summary = "Convert a Slack text event into a canonical bridge event in sandbox mode")
     @ApiResponse(responseCode = "503", description = "Slack bridge is disabled, unmapped, or not configured.",
             content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
-    public CanonicalBridgeEventResponse slackEvent(@Valid @RequestBody SlackEventRequest request) {
-        return interopGatewayService.ingestSlackEvent(request);
+    public CanonicalBridgeEventResponse slackEvent(
+            @RequestBody String rawBody,
+            @RequestHeader(name = "X-Slack-Request-Timestamp", required = false) String requestTimestamp,
+            @RequestHeader(name = "X-Slack-Signature", required = false) String requestSignature)
+            throws com.fasterxml.jackson.core.JsonProcessingException {
+        SlackEventRequest request = objectMapper.readValue(rawBody, SlackEventRequest.class);
+        return interopGatewayService.ingestSlackEvent(request, rawBody, requestTimestamp, requestSignature);
+    }
+
+    @PostMapping("/api/interop/slack/messages")
+    @Operation(summary = "Map a Weave text message to the Slack sandbox outbound adapter")
+    @ApiResponse(responseCode = "503", description = "Slack bridge is disabled, unmapped, or not configured.",
+            content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+    public SlackOutboundMessageResponse slackMessage(@Valid @RequestBody SlackOutboundMessageRequest request) {
+        return interopGatewayService.sendSlackMessage(request);
     }
 
     @GetMapping("/api/interop/teams/contract")

--- a/src/main/java/com/massimotter/weave/backend/model/interop/SlackEventRequest.java
+++ b/src/main/java/com/massimotter/weave/backend/model/interop/SlackEventRequest.java
@@ -9,5 +9,6 @@ public record SlackEventRequest(
         @NotBlank @Size(max = 128) String channelId,
         @NotBlank @Size(max = 128) String userId,
         @NotBlank @Size(max = 4096) String text,
-        @Size(max = 128) String threadTs) {
+        @Size(max = 128) String threadTs,
+        @Size(max = 128) String subtype) {
 }

--- a/src/main/java/com/massimotter/weave/backend/model/interop/SlackOutboundMessageRequest.java
+++ b/src/main/java/com/massimotter/weave/backend/model/interop/SlackOutboundMessageRequest.java
@@ -1,0 +1,10 @@
+package com.massimotter.weave.backend.model.interop;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record SlackOutboundMessageRequest(
+        @NotBlank @Size(max = 128) String eventId,
+        @NotBlank @Size(max = 4096) String text,
+        @Size(max = 128) String threadTs) {
+}

--- a/src/main/java/com/massimotter/weave/backend/model/interop/SlackOutboundMessageResponse.java
+++ b/src/main/java/com/massimotter/weave/backend/model/interop/SlackOutboundMessageResponse.java
@@ -1,0 +1,14 @@
+package com.massimotter.weave.backend.model.interop;
+
+import java.util.Map;
+
+public record SlackOutboundMessageResponse(
+        String idempotencyKey,
+        String provider,
+        String workspaceRef,
+        String channelRef,
+        String deliveryStatus,
+        boolean dryRunOnly,
+        boolean productionCallAttempted,
+        Map<String, Object> payload) {
+}

--- a/src/main/java/com/massimotter/weave/backend/service/interop/InteropGatewayService.java
+++ b/src/main/java/com/massimotter/weave/backend/service/interop/InteropGatewayService.java
@@ -6,6 +6,8 @@ import com.massimotter.weave.backend.model.interop.CanonicalBridgeEventResponse;
 import com.massimotter.weave.backend.model.interop.InteropStatusResponse;
 import com.massimotter.weave.backend.model.interop.SlackEventRequest;
 import com.massimotter.weave.backend.model.interop.SlackOAuthCallbackRequest;
+import com.massimotter.weave.backend.model.interop.SlackOutboundMessageRequest;
+import com.massimotter.weave.backend.model.interop.SlackOutboundMessageResponse;
 import com.massimotter.weave.backend.model.interop.SlackStatusResponse;
 import com.massimotter.weave.backend.model.interop.TeamsContractResponse;
 import java.util.LinkedHashMap;
@@ -19,10 +21,18 @@ public class InteropGatewayService {
 
     private final InteropGatewayProperties properties;
     private final IdempotencyKeyService idempotencyKeyService;
+    private final SlackSignatureVerifier slackSignatureVerifier;
+    private final SlackSecretResolver slackSecretResolver;
 
-    public InteropGatewayService(InteropGatewayProperties properties, IdempotencyKeyService idempotencyKeyService) {
+    public InteropGatewayService(
+            InteropGatewayProperties properties,
+            IdempotencyKeyService idempotencyKeyService,
+            SlackSignatureVerifier slackSignatureVerifier,
+            SlackSecretResolver slackSecretResolver) {
         this.properties = properties;
         this.idempotencyKeyService = idempotencyKeyService;
+        this.slackSignatureVerifier = slackSignatureVerifier;
+        this.slackSecretResolver = slackSecretResolver;
     }
 
     public InteropStatusResponse status() {
@@ -64,7 +74,7 @@ public class InteropGatewayService {
                 tokenRefConfigured,
                 mappingConfigured,
                 false,
-                List.of("rate_limited", "missing_mapping", "missing_consent", "signature_invalid", "delivery_degraded"),
+                List.of("rate_limited", "missing_mapping", "missing_consent", "signature_invalid", "delivery_degraded", "loop_prevented"),
                 slackActions(oauthConfigured, signingConfigured, tokenRefConfigured, mappingConfigured));
     }
 
@@ -81,10 +91,19 @@ public class InteropGatewayService {
     }
 
     public CanonicalBridgeEventResponse ingestSlackEvent(SlackEventRequest request) {
+        return ingestSlackEvent(request, null, null, null);
+    }
+
+    public CanonicalBridgeEventResponse ingestSlackEvent(
+            SlackEventRequest request,
+            String rawBody,
+            String requestTimestamp,
+            String requestSignature) {
         SlackStatusResponse status = slackStatus();
         if (!status.enabled()) {
             throw disabled("slack-events");
         }
+        verifySlackSignature(rawBody, requestTimestamp, requestSignature);
         if (!status.channelMappingConfigured()) {
             throw new ApiErrorException(
                     HttpStatus.SERVICE_UNAVAILABLE,
@@ -92,11 +111,19 @@ public class InteropGatewayService {
                     "Slack bridge mapping is not configured.",
                     Map.of("module", "interop", "provider", "slack", "operation", "ingest-event"));
         }
+        if ("bot_message".equals(request.subtype())) {
+            throw new ApiErrorException(
+                    HttpStatus.CONFLICT,
+                    "slack-loop-prevented",
+                    "Slack bridge ignored a provider event that appears to come from a bridged bot message.",
+                    Map.of("module", "interop", "provider", "slack", "operation", "ingest-event"));
+        }
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("text", request.text());
         payload.put("externalEventId", request.eventId());
         payload.put("channelId", request.channelId());
         payload.put("threadTs", request.threadTs());
+        payload.put("loopPrevention", "bot_message events are rejected before mapping");
         return new CanonicalBridgeEventResponse(
                 idempotencyKeyService.key("slack:event", request.teamId() + ":" + request.eventId()),
                 "slack",
@@ -109,6 +136,33 @@ public class InteropGatewayService {
                 true);
     }
 
+    public SlackOutboundMessageResponse sendSlackMessage(SlackOutboundMessageRequest request) {
+        SlackStatusResponse status = slackStatus();
+        if (!status.enabled()) {
+            throw disabled("slack-send-message");
+        }
+        if (!status.channelMappingConfigured()) {
+            throw new ApiErrorException(
+                    HttpStatus.SERVICE_UNAVAILABLE,
+                    "slack-mapping-unavailable",
+                    "Slack bridge mapping is not configured.",
+                    Map.of("module", "interop", "provider", "slack", "operation", "send-message"));
+        }
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("text", request.text());
+        payload.put("threadTs", request.threadTs());
+        payload.put("loopPrevention", "outbound sandbox does not call Slack and uses idempotency before delivery");
+        return new SlackOutboundMessageResponse(
+                idempotencyKeyService.key("weave:slack:message", properties.slack().channelId() + ":" + request.eventId()),
+                "slack",
+                properties.slack().workspaceId(),
+                properties.slack().channelId(),
+                "sandbox-not-delivered",
+                true,
+                false,
+                payload);
+    }
+
     public Map<String, Object> oauthCallback(SlackOAuthCallbackRequest request) {
         if (!slackStatus().enabled()) {
             throw disabled("oauth-callback");
@@ -118,6 +172,29 @@ public class InteropGatewayService {
                 "installed", false,
                 "credentialStored", false,
                 "message", "Slack OAuth skeleton is wired; token exchange remains disabled until secret brokering is configured.");
+    }
+
+    private void verifySlackSignature(String rawBody, String requestTimestamp, String requestSignature) {
+        if (rawBody == null && requestTimestamp == null && requestSignature == null) {
+            return;
+        }
+        String signingSecretRef = properties.slack().signingSecretRef();
+        if (!hasText(rawBody) || !hasText(requestTimestamp) || !hasText(requestSignature) || !hasText(signingSecretRef)) {
+            throw signatureInvalid("missing Slack signature metadata");
+        }
+        String signingSecret = slackSecretResolver.resolveSigningSecret(signingSecretRef)
+                .orElseThrow(() -> signatureInvalid("Slack signing secret reference is not resolvable"));
+        if (!slackSignatureVerifier.verify(signingSecret, requestTimestamp, rawBody, requestSignature)) {
+            throw signatureInvalid("Slack request signature did not verify");
+        }
+    }
+
+    private ApiErrorException signatureInvalid(String reason) {
+        return new ApiErrorException(
+                HttpStatus.UNAUTHORIZED,
+                "slack-signature-invalid",
+                "Slack request signature could not be verified.",
+                Map.of("module", "interop", "provider", "slack", "operation", "ingest-event", "reason", reason));
     }
 
     private InteropStatusResponse.ExternalConnectionResponse slackConnection() {

--- a/src/main/java/com/massimotter/weave/backend/service/interop/NoopSlackSecretResolver.java
+++ b/src/main/java/com/massimotter/weave/backend/service/interop/NoopSlackSecretResolver.java
@@ -1,0 +1,12 @@
+package com.massimotter.weave.backend.service.interop;
+
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NoopSlackSecretResolver implements SlackSecretResolver {
+    @Override
+    public Optional<String> resolveSigningSecret(String signingSecretRef) {
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/massimotter/weave/backend/service/interop/SlackSecretResolver.java
+++ b/src/main/java/com/massimotter/weave/backend/service/interop/SlackSecretResolver.java
@@ -1,0 +1,7 @@
+package com.massimotter.weave.backend.service.interop;
+
+import java.util.Optional;
+
+public interface SlackSecretResolver {
+    Optional<String> resolveSigningSecret(String signingSecretRef);
+}

--- a/src/test/java/com/massimotter/weave/backend/controller/OpenApiDocumentationTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/OpenApiDocumentationTest.java
@@ -62,6 +62,7 @@ class OpenApiDocumentationTest {
                 .andExpect(jsonPath("$.paths['/api/interop/slack/status']").exists())
                 .andExpect(jsonPath("$.paths['/api/interop/slack/oauth/callback']").exists())
                 .andExpect(jsonPath("$.paths['/api/interop/slack/events']").exists())
+                .andExpect(jsonPath("$.paths['/api/interop/slack/messages']").exists())
                 .andExpect(jsonPath("$.paths['/api/interop/teams/contract']").exists())
                 .andExpect(jsonPath("$.paths['/api/guest/access-contract']").exists())
                 .andExpect(jsonPath("$.paths['/api/guest/invitations']").exists())

--- a/src/test/java/com/massimotter/weave/backend/controller/SlackBridgeControllerTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/SlackBridgeControllerTest.java
@@ -1,0 +1,155 @@
+package com.massimotter.weave.backend.controller;
+
+import com.massimotter.weave.backend.service.interop.SlackSecretResolver;
+import java.nio.charset.StandardCharsets;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(properties = {
+        "spring.security.oauth2.resourceserver.jwt.issuer-uri=https://auth.example.invalid/realms/weave",
+        "weave.interop.enabled=true",
+        "weave.interop.slack.enabled=true",
+        "weave.interop.slack.client-id=client-id",
+        "weave.interop.slack.client-secret-ref=secret://slack/client-secret",
+        "weave.interop.slack.signing-secret-ref=secret://slack/signing-secret",
+        "weave.interop.slack.token-ref=secret://slack/bot-token",
+        "weave.interop.slack.workspace-id=T123",
+        "weave.interop.slack.channel-id=C123",
+        "weave.interop.slack.room-id=!room:weave.local"
+})
+@AutoConfigureMockMvc
+class SlackBridgeControllerTest {
+
+    private static final String SIGNING_SECRET = "test-signing-secret";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JwtDecoder jwtDecoder;
+
+    @MockBean
+    private SlackSecretResolver slackSecretResolver;
+
+    @Test
+    void rejectsInboundSlackEventWithoutVerifiableSignature() throws Exception {
+        when(slackSecretResolver.resolveSigningSecret(eq("secret://slack/signing-secret")))
+                .thenReturn(java.util.Optional.of(SIGNING_SECRET));
+
+        mockMvc.perform(post("/api/interop/slack/events")
+                        .with(workspaceJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(slackEventBody(null)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("slack-signature-invalid"));
+    }
+
+    @Test
+    void mapsSignedInboundSlackTextEventToCanonicalSandboxEvent() throws Exception {
+        when(slackSecretResolver.resolveSigningSecret(eq("secret://slack/signing-secret")))
+                .thenReturn(java.util.Optional.of(SIGNING_SECRET));
+        String body = slackEventBody(null);
+        String timestamp = "1710000000";
+
+        mockMvc.perform(post("/api/interop/slack/events")
+                        .with(workspaceJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-Slack-Request-Timestamp", timestamp)
+                        .header("X-Slack-Signature", slackSignature(timestamp, body))
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.provider").value("slack"))
+                .andExpect(jsonPath("$.roomRef").value("!room:weave.local"))
+                .andExpect(jsonPath("$.dryRunOnly").value(true))
+                .andExpect(content().string(not(containsString("secret://slack"))));
+    }
+
+    @Test
+    void preventsSlackBotMessageLoopBeforeMapping() throws Exception {
+        when(slackSecretResolver.resolveSigningSecret(eq("secret://slack/signing-secret")))
+                .thenReturn(java.util.Optional.of(SIGNING_SECRET));
+        String body = slackEventBody("bot_message");
+        String timestamp = "1710000001";
+
+        mockMvc.perform(post("/api/interop/slack/events")
+                        .with(workspaceJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-Slack-Request-Timestamp", timestamp)
+                        .header("X-Slack-Signature", slackSignature(timestamp, body))
+                        .content(body))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("slack-loop-prevented"));
+    }
+
+    @Test
+    void outboundSlackMessageStaysSandboxOnlyAndIdempotent() throws Exception {
+        mockMvc.perform(post("/api/interop/slack/messages")
+                        .with(workspaceJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "eventId": "weave-message-1",
+                                  "text": "hello from Weave"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.provider").value("slack"))
+                .andExpect(jsonPath("$.channelRef").value("C123"))
+                .andExpect(jsonPath("$.deliveryStatus").value("sandbox-not-delivered"))
+                .andExpect(jsonPath("$.dryRunOnly").value(true))
+                .andExpect(jsonPath("$.productionCallAttempted").value(false))
+                .andExpect(content().string(not(containsString("secret://slack"))));
+    }
+
+    private String slackEventBody(String subtype) {
+        String subtypeField = subtype == null ? "" : ",\n  \"subtype\": \"" + subtype + "\"";
+        return """
+                {
+                  "eventId": "E123",
+                  "teamId": "T123",
+                  "channelId": "C123",
+                  "userId": "U123",
+                  "text": "hello from Slack",
+                  "threadTs": null%s
+                }
+                """.formatted(subtypeField);
+    }
+
+    private String slackSignature(String timestamp, String body) throws Exception {
+        Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(new SecretKeySpec(SIGNING_SECRET.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+        byte[] digest = mac.doFinal(("v0:" + timestamp + ":" + body).getBytes(StandardCharsets.UTF_8));
+        StringBuilder builder = new StringBuilder("v0=");
+        for (byte b : digest) {
+            builder.append(String.format("%02x", b));
+        }
+        return builder.toString();
+    }
+
+    private org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.JwtRequestPostProcessor workspaceJwt() {
+        return jwt().jwt(jwt -> jwt
+                        .issuer("https://auth.example.invalid/realms/weave")
+                        .subject("owner-123")
+                        .claim("workspace_id", "weave-dev"))
+                .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"));
+    }
+}

--- a/src/test/java/com/massimotter/weave/backend/service/interop/InteropCoreServiceTest.java
+++ b/src/test/java/com/massimotter/weave/backend/service/interop/InteropCoreServiceTest.java
@@ -1,12 +1,15 @@
 package com.massimotter.weave.backend.service.interop;
 
 import com.massimotter.weave.backend.config.InteropGatewayProperties;
+import com.massimotter.weave.backend.exception.ApiErrorException;
 import com.massimotter.weave.backend.model.interop.CanonicalBridgeEventResponse;
 import com.massimotter.weave.backend.model.interop.SlackEventRequest;
+import com.massimotter.weave.backend.model.interop.SlackOutboundMessageRequest;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class InteropCoreServiceTest {
 
@@ -23,6 +26,44 @@ class InteropCoreServiceTest {
 
     @Test
     void enabledSlackSandboxMapsTextEventWithoutSecretOrProductionDelivery() {
+        InteropGatewayService service = enabledService();
+
+        CanonicalBridgeEventResponse event = service.ingestSlackEvent(
+                new SlackEventRequest("E123", "T123", "C123", "U123", "hello", null, null));
+
+        assertThat(event.provider()).isEqualTo("slack");
+        assertThat(event.roomRef()).isEqualTo("room-123");
+        assertThat(event.dryRunOnly()).isTrue();
+        assertThat(event.payload()).containsEntry("text", "hello");
+        assertThat(event.toString()).doesNotContain("secret://");
+    }
+
+    @Test
+    void outboundSlackSandboxMapsMessageWithoutProviderDelivery() {
+        InteropGatewayService service = enabledService();
+
+        var response = service.sendSlackMessage(new SlackOutboundMessageRequest("W1", "hello from Weave", null));
+
+        assertThat(response.provider()).isEqualTo("slack");
+        assertThat(response.channelRef()).isEqualTo("C123");
+        assertThat(response.deliveryStatus()).isEqualTo("sandbox-not-delivered");
+        assertThat(response.dryRunOnly()).isTrue();
+        assertThat(response.productionCallAttempted()).isFalse();
+        assertThat(response.toString()).doesNotContain("secret://");
+    }
+
+    @Test
+    void slackSandboxPreventsBotMessageLoopsBeforeMapping() {
+        InteropGatewayService service = enabledService();
+
+        assertThatThrownBy(() -> service.ingestSlackEvent(
+                        new SlackEventRequest("E123", "T123", "C123", "U123", "loop", null, "bot_message")))
+                .isInstanceOf(ApiErrorException.class)
+                .extracting("code")
+                .isEqualTo("slack-loop-prevented");
+    }
+
+    private InteropGatewayService enabledService() {
         InteropGatewayProperties properties = new InteropGatewayProperties(
                 true,
                 new InteropGatewayProperties.Provider(
@@ -36,16 +77,11 @@ class InteropCoreServiceTest {
                         "room-123"),
                 null,
                 "support-safe-redacted");
-        InteropGatewayService service = new InteropGatewayService(properties, new IdempotencyKeyService());
-
-        CanonicalBridgeEventResponse event = service.ingestSlackEvent(
-                new SlackEventRequest("E123", "T123", "C123", "U123", "hello", null));
-
-        assertThat(event.provider()).isEqualTo("slack");
-        assertThat(event.roomRef()).isEqualTo("room-123");
-        assertThat(event.dryRunOnly()).isTrue();
-        assertThat(event.payload()).containsEntry("text", "hello");
-        assertThat(event.toString()).doesNotContain("secret://");
+        return new InteropGatewayService(
+                properties,
+                new IdempotencyKeyService(),
+                new SlackSignatureVerifier(),
+                ignored -> java.util.Optional.of("signing-secret"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- wires the Slack one-channel proof behind the existing disabled-by-default interop flags
- requires Slack request signature verification for controller ingress, rejects bot-message loops, and keeps outbound Weave-to-Slack delivery sandbox-only/idempotent
- documents the Release 2 interop/guest/migration runtime flags and secret-reference boundaries

Closes #40.

## Validation
- `./gradlew test`

## Contract impact
- Adds `POST /api/interop/slack/messages` as a sandbox outbound adapter endpoint.
- Extends Slack event payloads with optional `subtype` for loop prevention.
- No Release 1 runtime activation; `WEAVE_INTEROP_ENABLED` and `WEAVE_INTEROP_SLACK_ENABLED` remain false by default.
- No raw Slack secrets/tokens accepted in API payloads or returned in responses.
