### PR TITLE
docs: align active Calendar, E2EE, and Boards backend scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 [![CI](https://github.com/masssi164/weave-backend/actions/workflows/ci.yml/badge.svg)](https://github.com/masssi164/weave-backend/actions/workflows/ci.yml)
 
-`weave-backend` is the Spring Boot product API for Weave. It keeps Release 1 client contracts small and supportable, avoids pushing backend-owned secrets or raw downstream protocols into clients, and leaves room for the broader Weave vision: accessible workspaces, open operator control, data sovereignty, and a future Weaver intelligence layer for assistants, agents, automation, and connectors.
+`weave-backend` is the Spring Boot product API for Weave. It keeps active client contracts small and supportable, avoids pushing backend-owned secrets or raw downstream protocols into clients, and leaves room for the broader Weave vision: accessible workspaces, open operator control, data sovereignty, and a later Weaver intelligence layer for assistants, agents, automation, and connectors.
 
 The backend is intentionally **not** a generic proxy for Matrix, Nextcloud, or Keycloak. Flutter can use native OIDC/PKCE and Matrix client flows where that is the right protocol boundary. This service owns the workflows that benefit from a server-side product layer: normalized Weave APIs, stable error envelopes, release-readiness checks, backend-owned integrations, and orchestration that should not live in the app.
 
-## Release 1 scope
+## Active product/API scope
 
-Release 1 is an early operator-facing slice, not the full Teams/Slack migration story yet. The backend currently provides:
+The backend is an active product facade for the MVP collaboration surfaces. Some runtime slices remain feature-gated while contracts, auth, accessibility, and operator validation mature. The backend currently provides:
 
 - public health and platform bootstrap endpoints for gateway and smoke checks
 - first-party JWT issuer, audience, client, and `weave:workspace` scope validation
@@ -17,12 +17,12 @@ Release 1 is an early operator-facing slice, not the full Teams/Slack migration 
 - first-run onboarding status at `/api/onboarding/status`
 - workspace capability and release-readiness snapshots at `/api/workspace/capabilities` and `/api/workspace/release-readiness`
 - Nextcloud-backed Files facade endpoints when a backend-owned actor is configured; otherwise they fail closed
-- Calendar facade endpoints mapped to the backend actor's Nextcloud CalDAV workspace calendar when configured; unsafe private-user calendar templates fail closed
-- secret-free Calendar client setup metadata at `GET /api/calendar/client-setup` for Release 2 profile/download planning; it does not return credentials or generate profiles yet
+- Calendar facade endpoints mapped to the backend actor's Nextcloud CalDAV workspace calendar fallback while workspace/team/channel scheduling scopes are implemented; unsafe private-personal calendar templates fail closed
+- secret-free Calendar client setup metadata at `GET /api/calendar/client-setup` for feature-gated native-client setup; it does not return credentials or generate profiles yet
 - OpenAPI JSON at `/v3/api-docs`
 - Actuator health/info endpoints, Gradle wrapper, Dockerfile, and GitHub Actions CI
 
-Release 1 does **not** claim a complete Teams/Slack replacement, end-user credential brokering, full Matrix/Nextcloud provisioning automation, recurrence-rich calendar UX, sharing/move policy, Boards/Tasks product navigation, or the future Weaver intelligence layer. Those remain product-roadmap items behind explicit contracts. The hidden Boards/Tasks preview contract is documented separately in [docs/boards-preview-contract.md](docs/boards-preview-contract.md) and must not be treated as a Release 1 enabled surface.
+The current backend does **not** yet claim a complete Teams/Slack replacement, end-user credential brokering, full Matrix/Nextcloud provisioning automation, recurrence-rich calendar UX, sharing/move policy, live Boards/Tasks provider runtime, or the later Weaver intelligence layer. Those remain product-roadmap items behind explicit contracts. The hidden Boards/Tasks preview contract is documented separately in [docs/boards-preview-contract.md](docs/boards-preview-contract.md) and must not be treated as a live-provider-enabled surface.
 
 ## Product boundary
 
@@ -38,7 +38,7 @@ Avoid using it to replace standards-based native flows by default:
 
 - no custom server-side login proxy in front of Matrix Native OAuth 2.0
 - no assumption that a mobile OIDC bearer token can be reused as a Matrix access token
-- no direct Flutter-to-Nextcloud WebDAV/OCS/CalDAV contract as the default Release 1 product API
+- no direct Flutter-to-Nextcloud WebDAV/OCS/CalDAV contract as the default live product API
 
 ## Repo compass
 
@@ -46,10 +46,10 @@ Avoid using it to replace standards-based native flows by default:
 - `src/main/resources/application.yml`: runtime defaults and environment-variable bindings.
 - `src/test/java/...`: contract and service tests for auth, profiles, readiness, files, and calendar behavior.
 - `docs/runtime-configuration.md`: complete environment-variable reference and fail-closed adapter behavior.
-- `docs/release-operations.md`: Release 1 API operations guide and minimum operator checks.
-- `docs/calendar-client-setup.md`: Release 2 research and phased plan for Apple `.mobileconfig`, Android DAVx5, desktop CalDAV, and read-only webcal/ICS setup.
+- `docs/release-operations.md`: Backend API operations guide and minimum operator checks.
+- `docs/calendar-client-setup.md`: active research and phased plan for Apple `.mobileconfig`, Android DAVx5, desktop CalDAV, and read-only webcal/ICS setup.
 - `docs/architecture-alignment.md`: cross-repo responsibility split for app, backend, and infrastructure.
-- `docs/boards-preview-contract.md`: hidden, post-Release-1 Boards/Tasks provider-neutral contract notes; not a Product screenshots or Release 1 surface.
+- `docs/boards-preview-contract.md`: active feature-gated Boards/Tasks provider-neutral contract notes; not a Product screenshots or live product surface.
 - `docs/issues/`: historical alignment issue drafts.
 
 ## Quick start
@@ -93,6 +93,6 @@ Protected `/api/**` routes require a bearer token whose `iss`, `aud`, `azp`/`cli
 ## Operator notes
 
 - Runtime variables and backend-owned actor credentials are documented in [docs/runtime-configuration.md](docs/runtime-configuration.md).
-- Release 1 readiness, stable auth errors, and minimum smoke checks are documented in [docs/release-operations.md](docs/release-operations.md).
+- workspace readiness, stable auth errors, and minimum smoke checks are documented in [docs/release-operations.md](docs/release-operations.md).
 - Keep issuer/JWKS/client/audience values aligned with the public auth contract exposed to the app.
 - Do not log raw bearer tokens, Nextcloud actor tokens, app passwords, or CalDAV credentials.

--- a/docs/boards-preview-contract.md
+++ b/docs/boards-preview-contract.md
@@ -1,8 +1,8 @@
 # Boards/Tasks preview contract
 
-Boards/Tasks is a provider-neutral, post-Release-1 preview slice. It is **not** a Release 1 product surface. The only reachable runtime slice is a hidden, authenticated, feature-flagged local preview facade; live provider adapters remain disabled until a later promotion spec defines provider auth, DTO compatibility, OpenAPI publication, runtime setup, smoke/E2E, and accessibility gates.
+Boards/Tasks is a provider-neutral, active feature-gated preview slice. It is **not** a live product surface. The only reachable runtime slice is a hidden, authenticated, feature-flagged local preview facade; live provider adapters remain disabled until a later promotion spec defines provider auth, DTO compatibility, OpenAPI publication, runtime setup, smoke/E2E, and accessibility gates.
 
-This document is intentionally separate from Release 1 screenshots and product-surface documentation. Do not add Boards/Tasks screenshots to the main Product screenshots section unless the module is fully navigable and release-enabled by a later spec.
+This document is intentionally separate from Product screenshots and product-surface documentation. Do not add Boards/Tasks screenshots to the main Product screenshots section unless the module is fully navigable and release-enabled by a later spec.
 
 ## Scope in this backend slice
 
@@ -19,31 +19,31 @@ Implemented now:
 
 Not implemented now:
 
-- No Release 1 navigation or product enablement.
+- No live provider navigation or product enablement until promotion gates pass.
 - No live provider runtime configuration, secrets, Caddy routes, or smoke checks.
 - No user-facing screenshots.
 - No notifications, audit streams, webhooks, or automation consumers.
 
 ## Hidden preview API
 
-The hidden preview API is deliberately narrow and disabled by default:
+The feature-gated preview API is deliberately narrow and disabled by default for live providers:
 
 - `GET /api/boards/preview`
 - `POST /api/boards/{boardId}/tasks`
 - `POST /api/boards/tasks/{taskId}/move`
 - `POST /api/boards/tasks/{taskId}/complete`
 
-All routes require the normal authenticated `weave:workspace` backend boundary. They return provider-neutral Weave domain shapes and support-safe `boards-*` errors. The local adapter stores only in-memory preview data, exposes `releaseStatus = post-release-hidden-preview`, and must not be documented as a Release 1/customer-ready module.
+All routes require the normal authenticated `weave:workspace` backend boundary. They return provider-neutral Weave domain shapes and support-safe `boards-*` errors. The local adapter stores only in-memory preview data, exposes `releaseStatus = active-feature-gated-preview`, and must not be documented as a customer-ready module.
 
 ## 2026-05-14 issue/spec matrix
 
 | Track | Source | This implementation wave | Status |
 | --- | --- | --- | --- |
-| Boards/Tasks domain | Workspace spec `specs/14-boards-tasks-domain-and-provider-adapter-contract.md`; `weave` issues #119-#123 | Adds the hidden backend runtime slice and lets the Flutter hidden preview consume it when authenticated. | Implemented as post-Release hidden preview; not Release 1/product-enabled. |
-| Calendar private/workspace model | `weave-backend` #52 | Existing calendar facade remains workspace-scoped and private-user CalDAV stays fail-closed until the access model is finished. | Deferred from this Boards runtime PR; do not add fake private calendar UI. |
+| Boards/Tasks domain | Workspace spec `specs/14-boards-tasks-domain-and-provider-adapter-contract.md`; `weave` issues #119-#123 | Adds the feature-gated backend runtime slice and lets the Flutter feature-gated preview consume it when authenticated. | Implemented as active feature-gated preview; not live-provider-enabled. |
+| Calendar private/workspace model | `weave-backend` #52 | Existing calendar facade remains workspace-scoped and private-personal CalDAV stays fail-closed until the access model is finished. | Deferred from this Boards runtime PR; do not add fake private calendar UI. |
 | Calendar external CalDAV credentials/profile | `weave-backend` #56; `weave-infra` #54 | No credential/profile issuing in this wave because revocation, storage, redaction, and support-bundle handling are the acceptance gate. | Deferred; keep client setup secret-free and truthful. |
 
-Calendar follow-up must land as a separate security-focused wave before Apple `.mobileconfig`, DAVx5, desktop CalDAV discovery, or user-private calendar access is exposed.
+Calendar follow-up must land as a separate security-focused wave before Apple `.mobileconfig`, DAVx5, desktop CalDAV discovery, or private-personal calendar access is exposed.
 
 ## Provider-neutral model
 
@@ -85,11 +85,11 @@ All three fail closed with support-safe `provider_unavailable` errors until a pr
 - preserves ordering inputs such as source event id and provider timestamps in payload fields without publishing routes;
 - redacts support-unsafe payload keys such as tokens, secrets, raw messages, credentials, authorisation headers, and provider URLs before support-safe events leave the adapter boundary.
 
-This is still preview-only and has no notification, audit, webhook, or Release 1 runtime publication.
+This is still preview-only and has no notification, audit, webhook, or live runtime publication.
 
 ## Contract artifacts
 
 - `src/main/resources/contracts/boards-preview.openapi.yaml` contains preview schema components only and intentionally has `paths: {}`.
 - `src/main/resources/contracts/task-board-event.schema.json` contains the preview normalized event envelope.
 
-These artifacts are open contract drafts for implementation alignment; they are not a published Release 1 API surface.
+These artifacts are open contract drafts for implementation alignment; they are not a published live-provider API surface.

--- a/docs/calendar-client-setup.md
+++ b/docs/calendar-client-setup.md
@@ -1,6 +1,6 @@
 # Calendar client setup and profile download plan
 
-Release 2 should make Calendar a fully integrated Weave feature while still allowing users to connect native calendar clients where platforms support it. The app UI remains backed by the `/api/calendar/**` facade; external client setup is a separate standards bridge, not a direct Flutter-to-CalDAV product shortcut.
+Weave should make Calendar a fully integrated Weave feature while still allowing users to connect native calendar clients where platforms support it. The app UI remains backed by the `/api/calendar/**` facade; external client setup is a separate standards bridge, not a direct Flutter-to-CalDAV product shortcut.
 
 ## Research findings
 
@@ -8,7 +8,7 @@ Release 2 should make Calendar a fully integrated Weave feature while still allo
 
 Apple supports a Calendar configuration profile payload (`PayloadType = com.apple.caldav.account`) for iOS, iPadOS, macOS, Shared iPad user channel, and visionOS. The payload can carry the CalDAV host, port, SSL flag, principal URL, account description, username, and optionally a password. Apple documents that omitted passwords are entered by the user during install.
 
-Release 2 implications:
+Active product implications:
 
 - A Weave profile download can produce a `.mobileconfig` for Apple platforms.
 - The profile must be generated per user and should be signed before end-user release to avoid scary installation warnings and tampering concerns.
@@ -21,7 +21,7 @@ Release 2 implications:
 
 Android does not provide a universal OS-level CalDAV profile install equivalent. DAVx5 is the practical open CalDAV/CardDAV sync adapter. DAVx5 can be launched with explicit intents or `davx5://`, `caldav(s)://`, and `carddav(s)://` links, and can use the Nextcloud login flow so each client receives its own app password. ICS/webcal subscriptions are a separate one-way path; DAVx5 recommends ICSx5 for HTTP/Webcal `.ics` subscriptions.
 
-Release 2 implications:
+Active product implications:
 
 - Weave should expose a secret-free DAVx5 setup URL and copyable CalDAV discovery URL.
 - Android two-way sync depends on DAVx5 or another CalDAV sync adapter, not on Android Calendar alone.
@@ -36,7 +36,7 @@ Desktop support is fragmented:
 - GNOME/KDE calendar stacks can use CalDAV through their account/calendar integrations.
 - Outlook on Windows generally does not support CalDAV natively without an add-in; read-only ICS/webcal can help for subscription-only use cases.
 
-Release 2 implications:
+Active product implications:
 
 - Provide copyable CalDAV discovery/principal URLs and username for manual setup.
 - Provide a future read-only webcal/ICS feed for clients that cannot do CalDAV, backed by revocable tokens.
@@ -46,7 +46,7 @@ Release 2 implications:
 
 Nextcloud's Login Flow / Login Flow v2 issues per-client credentials/app passwords and lets users revoke clients. It is a safer fit than reusing the user's primary password or embedding backend credentials. Nextcloud also documents app password conversion and deletion endpoints for clients that already authenticate.
 
-Release 2 implications:
+Active product implications:
 
 - External clients need a per-client Nextcloud credential or future Weave-scoped token accepted at the CalDAV/subscription boundary.
 - The backend must never expose its service-account CalDAV credential to users or generated profiles.
@@ -57,14 +57,14 @@ Release 2 implications:
 `GET /api/calendar/client-setup` now exposes authenticated, secret-free setup metadata:
 
 - current calendar scope (`workspace`)
-- explicit access model metadata (`workspace-calendar`, private user calendars unavailable until a reviewed provisioning/sharing/delegated-token model exists)
+- explicit access model metadata (`workspace-calendar`, private personal calendars unavailable until a reviewed provisioning/sharing/delegated-token model exists)
 - profile/feed credential readiness metadata showing Apple profile signing, revocable credentials, and read-only subscription tokens are still blocked
 - current user's external calendar username
 - CalDAV discovery and principal URLs
 - platform option matrix for Apple `.mobileconfig`, Android DAVx5, desktop manual CalDAV, and webcal/ICS subscription
 - explicit credential policy that no password, bearer token, app password, or backend actor credential is returned
 
-This endpoint is intentionally not a profile generator yet. It creates the contract surface the app can show in a Release 2 profile/calendar-settings screen while keeping unsafe paths closed.
+This endpoint is intentionally not a profile generator yet. It creates the contract surface the app can show in a feature-gated profile/calendar-settings screen while keeping unsafe paths closed.
 
 ## Backend profile endpoint scaffold
 
@@ -72,7 +72,7 @@ This endpoint is intentionally not a profile generator yet. It creates the contr
 
 The renderer includes only CalDAV host, port, SSL, principal URL, display label, username, and profile metadata. It deliberately omits `CalDAVPassword` and never reads backend actor credentials, bearer tokens, or static setup secrets. Password-bearing profiles remain blocked until a revocable per-client credential issuance and revocation model exists.
 
-## Release 2 implementation sequence
+## Active implementation sequence
 
 1. **Contract and setup metadata (this PR):** expose `/api/calendar/client-setup` and document the platform/security model.
 2. **Access/credential readiness contract:** expose explicit access-model and credential-readiness fields so clients can show honest blocked states before any profile/feed download path exists. Keep `{user}` CalDAV templates fail-closed until tested.
@@ -80,7 +80,7 @@ The renderer includes only CalDAV host, port, SSL, principal URL, display label,
 4. **Apple profile generator:** keep the authenticated `.mobileconfig` endpoint fail-closed until profile signing is configured; then serve the tested no-secret profile through a signer, or include only a revocable scoped credential once issuance/revocation exists. Add tests proving no backend actor credential can appear in the profile.
 5. **Android setup handoff:** add app/UI support for DAVx5 setup URI, manual fallback instructions, and read-only subscription copy once tokenized ICS exists.
 6. **Read-only subscription tokens:** implement revocable webcal/ICS feed tokens for clients that cannot do CalDAV; label them one-way.
-7. **Calendar product promotion:** once create/read/update/delete and profile setup are safe, enable Calendar as a Release 2 module in app capability/navigation tests.
+7. **Calendar product promotion:** once create/read/update/delete and profile setup are safe, enable Calendar as a active module in app capability/navigation tests.
 8. **Boards/Tasks promotion:** after the provider-neutral API and Vikunja adapter are tested, enable Boards/Tasks with non-drag accessible movement as a hard release gate.
 
 ## References

--- a/docs/release-operations.md
+++ b/docs/release-operations.md
@@ -1,6 +1,6 @@
-# Release 1 API operations guide
+# Backend API operations guide
 
-This backend is intentionally small for Release 1, but operators still need a clear runtime contract.
+This backend is intentionally small, but operators still need a clear runtime contract.
 
 ## Runtime inputs
 
@@ -65,7 +65,7 @@ Use `401` for missing or invalid tokens. Use `403` when the token is authenticat
 
 `/api/onboarding/status` is the authenticated first-run user snapshot. It returns identity, role/group routing data, invite status, profile completeness, and frontend-safe provisioning states for identity, profile, Matrix, and Nextcloud. Matrix/Nextcloud states are `not_configured`, `pending`, `ready`, `degraded`, or `failed`; response messages must remain support-safe and must not expose downstream stack traces, secrets, tokens, or raw infrastructure errors.
 
-`/api/workspace/release-readiness` is the backend-owned operator snapshot for Release 1. It rolls auth, Matrix chat, and Nextcloud files into one response and lists the exact remaining setup actions when the workspace is still degraded or blocked.
+`/api/workspace/release-readiness` is the backend-owned operator snapshot for the core workspace. It rolls auth, Matrix chat, and Nextcloud files into one response and lists the exact remaining setup actions when the workspace is still degraded or blocked.
 
 The older `/api/v1/workspace/capabilities` and `/api/v1/workspace/release-readiness` paths remain compatibility aliases while clients migrate to the canonical non-versioned workspace routes.
 
@@ -80,11 +80,11 @@ The older `/api/v1/workspace/capabilities` and `/api/v1/workspace/release-readin
 - `GET /api/profile/sync-status` with a valid first-party token should return frontend-safe Matrix/Nextcloud profile sync state
 - `GET /api/onboarding/status` with a valid first-party token should return first-run invite, role/group, profile, Matrix, and Nextcloud provisioning status
 - `GET /api/workspace/capabilities` with a valid first-party token should return the client-facing capability snapshot
-- `GET /api/workspace/release-readiness` with a valid first-party token should return operator-facing Release 1 setup status and remaining actions
+- `GET /api/workspace/release-readiness` with a valid first-party token should return operator-facing workspace setup status and remaining actions
 
 ## Logging and audit baseline
 
-For Release 1, keep at least:
+For the core operator baseline, keep at least:
 
 - reverse proxy access logs with request path, status, latency, and request id
 - application logs from stdout/stderr collected by the deployment target

--- a/docs/runtime-configuration.md
+++ b/docs/runtime-configuration.md
@@ -1,6 +1,6 @@
 # Runtime configuration
 
-This document is the backend runtime reference for Release 1 operators and local integration runs. The top-level README keeps the product boundary short; this file keeps the full environment-variable contract in one place.
+This document is the backend runtime reference for operators and local integration runs. The top-level README keeps the product boundary short; this file keeps the full environment-variable contract in one place.
 
 ## Required runtime variable
 
@@ -52,7 +52,7 @@ The app never sends raw Nextcloud credentials to this backend. Files operations 
 - `WEAVE_NEXTCLOUD_FILES_APP_PASSWORD`: compatibility alias used when `WEAVE_NEXTCLOUD_FILES_ACTOR_TOKEN` is blank.
 - `WEAVE_NEXTCLOUD_FILES_WEBDAV_ROOT_PATH`: Nextcloud WebDAV files root path, defaults to `/remote.php/dav/files`.
 
-If the actor model, username, or token is missing, files endpoints fail closed with `nextcloud-adapter-not-configured`. Implemented Release 1 WebDAV operations are folder listing with quota when returned by Nextcloud, folder creation, upload, download, and delete. Move/share remain unsupported until product policy and endpoint contracts are specified.
+If the actor model, username, or token is missing, files endpoints fail closed with `nextcloud-adapter-not-configured`. Implemented WebDAV operations are folder listing with quota when returned by Nextcloud, folder creation, upload, download, and delete. Move/share remain unsupported until product policy and endpoint contracts are specified.
 
 ## Calendar facade and CalDAV adapter
 
@@ -65,9 +65,9 @@ Calendar product operations stay on `/api`; this backend is the only component t
 - `WEAVE_CALDAV_BACKEND_TOKEN`: backend actor app password/token or bearer token; required for the CalDAV adapter to call Nextcloud.
 - `WEAVE_CALDAV_REQUEST_TIMEOUT_SECONDS`: CalDAV request timeout, defaults to `10`.
 
-The Release 1 calendar facade is explicitly scoped to the Weave workspace calendar owned by the backend actor. `WEAVE_CALDAV_CALENDAR_PATH_TEMPLATE` values containing `{user}` are treated as private-user calendar targets and fail closed with `nextcloud-adapter-not-configured` until a reviewed provisioning/sharing/delegated-token model is specified. The facade responses include `scope.type = "workspace"` so clients do not present this first slice as a private per-user calendar.
+The active Calendar facade is explicitly scoped to the Weave workspace calendar owned by the backend actor. `WEAVE_CALDAV_CALENDAR_PATH_TEMPLATE` values containing `{user}` are treated as private-personal calendar targets and fail closed with `nextcloud-adapter-not-configured` until a reviewed provisioning/sharing/delegated-token model is specified. The facade responses include `scope.type = "workspace"` so clients do not present this first slice as a private per-user calendar.
 
-When required actor credentials are missing or an unsafe private-user template is configured, calendar operations fail closed with `nextcloud-adapter-not-configured`. Recurrence creation, editing, and expansion are deferred: the current DTO has no RRULE contract, and the adapter does not expose raw recurrence fields. Recurring events returned by CalDAV may appear as their source VEVENT only until a later product/API spec defines full recurrence UX.
+When required actor credentials are missing or an unsafe private-personal template is configured, calendar operations fail closed with `nextcloud-adapter-not-configured`. Recurrence creation, editing, and expansion are deferred: the current DTO has no RRULE contract, and the adapter does not expose raw recurrence fields. Recurring events returned by CalDAV may appear as their source VEVENT only until a later product/API spec defines full recurrence UX.
 
 ## Profile and onboarding variables
 
@@ -75,13 +75,13 @@ When required actor credentials are missing or an unsafe private-user template i
 - `WEAVE_ONBOARDING_MATRIX_PROVISIONING_STATE`: optional first-run Matrix provisioning override (`not_configured`, `pending`, `ready`, `degraded`, `failed`); blank derives status from chat capability.
 - `WEAVE_ONBOARDING_NEXTCLOUD_PROVISIONING_STATE`: optional first-run Nextcloud provisioning override (`not_configured`, `pending`, `ready`, `degraded`, `failed`); blank derives status from files/calendar capability and Nextcloud route configuration.
 
-Profile facade endpoints are protected by the same first-party bearer-token contract as `/api/me`. `PATCH /api/profile` accepts partial updates for `displayName`, `avatar`, `locale`, `timezone`, `accessibilityPreferences`, and `profileVisibility`. Set `WEAVE_PROFILE_STORAGE_PATH` to mounted durable storage for containerized Release 1 runs.
+Profile facade endpoints are protected by the same first-party bearer-token contract as `/api/me`. `PATCH /api/profile` accepts partial updates for `displayName`, `avatar`, `locale`, `timezone`, `accessibilityPreferences`, and `profileVisibility`. Set `WEAVE_PROFILE_STORAGE_PATH` to mounted durable storage for containerized runs.
 
 Onboarding status returns identity, roles, groups, invite status, profile completeness, and module provisioning states. Downstream states must remain frontend-safe and must not expose stack traces, tokens, secrets, or raw service errors.
 
 ## Interop gateway, Slack on-ramp, guests, and migration previews
 
-Release 1 keeps interop, guest access, and migration/import execution disabled by default. The backend exposes contract/readiness surfaces so Release 2 work can be validated without making Slack, Teams, guest portal, connector SDK, or migration runtime behavior a Release 1 dependency.
+Interop, guest access, and migration/import execution remain disabled by default. The backend exposes contract/readiness surfaces so feature-gated work can be validated without making Slack, Teams, guest portal, connector SDK, or migration runtime behavior a core dependency.
 
 - `WEAVE_INTEROP_ENABLED`: master interop gateway flag, defaults to `false`.
 - `WEAVE_INTEROP_SUPPORT_BUNDLE_REDACTION_MODE`: support bundle redaction mode label, defaults to `support-safe-redacted`.

--- a/src/main/java/com/massimotter/weave/backend/boards/deck/NextcloudDeckBoardsRepository.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/deck/NextcloudDeckBoardsRepository.java
@@ -44,7 +44,7 @@ public final class NextcloudDeckBoardsRepository implements BoardsRepository {
                         BoardCapability.CHECKLISTS,
                         BoardCapability.CUSTOM_FIELDS,
                         BoardCapability.ACCESSIBLE_NON_DRAG_MOVES),
-                "Nextcloud Deck is a disabled bridge/import adapter contract, not the Weave product model or a Release 1 runtime provider.");
+                "Nextcloud Deck is a disabled bridge/import adapter contract, not the Weave product model or a live runtime provider.");
     }
 
     @Override public BoardPage<WeaveProject> listProjects(BoardQuery query) { throw disabled(); }

--- a/src/main/java/com/massimotter/weave/backend/boards/openproject/OpenProjectBoardsRepository.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/openproject/OpenProjectBoardsRepository.java
@@ -44,7 +44,7 @@ public final class OpenProjectBoardsRepository implements BoardsRepository {
                         BoardCapability.INCREMENTAL_SYNC,
                         BoardCapability.CHECKLISTS,
                         BoardCapability.ACCESSIBLE_NON_DRAG_MOVES),
-                "OpenProject is a disabled accessibility and mature-workflow benchmark adapter contract, not a Release 1 runtime provider.");
+                "OpenProject is a disabled accessibility and mature-workflow benchmark adapter contract, not a live runtime provider.");
     }
 
     @Override public BoardPage<WeaveProject> listProjects(BoardQuery query) { throw disabled(); }

--- a/src/main/java/com/massimotter/weave/backend/boards/port/BoardsPreviewGuard.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/port/BoardsPreviewGuard.java
@@ -4,7 +4,7 @@ import com.massimotter.weave.backend.boards.support.BoardsErrorCode;
 import com.massimotter.weave.backend.boards.support.BoardsException;
 
 /**
- * Central guard for the post-Release-1 Boards/Tasks slice. Keeping this guard near
+ * Central guard for the active feature-gated Boards/Tasks slice. Keeping this guard near
  * the repository port prevents exploratory adapters from accidentally becoming a
  * reachable product API before a promotion spec defines routes, auth scopes, DTOs,
  * OpenAPI publication, smoke, E2E, and accessibility gates.
@@ -21,7 +21,7 @@ public final class BoardsPreviewGuard {
         if (!enabled) {
             throw new BoardsException(
                     BoardsErrorCode.PROVIDER_UNAVAILABLE,
-                    "Boards and tasks are a hidden preview module and are not enabled for Release 1.");
+                    "Boards and tasks are a feature-gated preview module and are feature-gated until runtime validation passes.");
         }
     }
 

--- a/src/main/java/com/massimotter/weave/backend/boards/port/NoopTaskBoardEventPublisher.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/port/NoopTaskBoardEventPublisher.java
@@ -6,7 +6,7 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * Safe default for the hidden Boards preview slice. It validates the event envelope
- * without enabling notifications, audit streams, webhooks, or Release 1 behavior.
+ * without enabling notifications, audit streams, webhooks, or live runtime behavior.
  */
 public final class NoopTaskBoardEventPublisher implements TaskBoardEventPublisher {
 

--- a/src/main/java/com/massimotter/weave/backend/boards/vikunja/VikunjaBoardsRepository.java
+++ b/src/main/java/com/massimotter/weave/backend/boards/vikunja/VikunjaBoardsRepository.java
@@ -44,7 +44,7 @@ public final class VikunjaBoardsRepository implements BoardsRepository {
                         BoardCapability.CHECKLISTS,
                         BoardCapability.ACCESSIBLE_NON_DRAG_MOVES),
                 EnumSet.of(BoardCapability.CUSTOM_FIELDS),
-                "Vikunja is the first adapter boundary, but the Boards/Tasks module is hidden and disabled for Release 1.");
+                "Vikunja is the first adapter boundary, but the Boards/Tasks module is feature-gated and disabled until runtime validation passes.");
     }
 
     @Override

--- a/src/main/java/com/massimotter/weave/backend/config/CalendarCalDavProperties.java
+++ b/src/main/java/com/massimotter/weave/backend/config/CalendarCalDavProperties.java
@@ -36,7 +36,7 @@ public record CalendarCalDavProperties(
     }
 
     public String calendarScope() {
-        return targetsPrivateUserCalendar() ? "private-user" : "workspace";
+        return targetsPrivateUserCalendar() ? "private-personal" : "workspace";
     }
 
     public enum AuthMode {

--- a/src/main/java/com/massimotter/weave/backend/controller/WorkspaceController.java
+++ b/src/main/java/com/massimotter/weave/backend/controller/WorkspaceController.java
@@ -50,13 +50,13 @@ public class WorkspaceController {
 
     @GetMapping({"/api/workspace/release-readiness", "/api/v1/workspace/release-readiness"})
     @Operation(
-            summary = "Get Release 1 workspace readiness",
-            description = "Returns an operator-facing snapshot of the backend-owned Release 1 dependencies and remaining setup actions.",
+            summary = "Get workspace readiness",
+            description = "Returns an operator-facing snapshot of the backend-owned core dependencies and remaining setup actions.",
             security = @SecurityRequirement(name = "bearer-jwt"))
     @ApiResponses({
             @ApiResponse(
                     responseCode = "200",
-                    description = "Workspace Release 1 readiness snapshot.",
+                    description = "Workspace workspace readiness snapshot.",
                     content = @Content(schema = @Schema(implementation = WorkspaceReleaseReadinessResponse.class))),
             @ApiResponse(responseCode = "401", description = "Missing or invalid bearer token.",
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),

--- a/src/main/java/com/massimotter/weave/backend/model/WorkspaceReleaseReadinessCheckResponse.java
+++ b/src/main/java/com/massimotter/weave/backend/model/WorkspaceReleaseReadinessCheckResponse.java
@@ -2,7 +2,7 @@ package com.massimotter.weave.backend.model;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(description = "One operator-facing Release 1 readiness check.")
+@Schema(description = "One operator-facing workspace readiness check.")
 public record WorkspaceReleaseReadinessCheckResponse(
         @Schema(description = "Stable check identifier.", example = "chat")
         String key,

--- a/src/main/java/com/massimotter/weave/backend/model/WorkspaceReleaseReadinessResponse.java
+++ b/src/main/java/com/massimotter/weave/backend/model/WorkspaceReleaseReadinessResponse.java
@@ -3,13 +3,13 @@ package com.massimotter.weave.backend.model;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
-@Schema(description = "Operator-facing Release 1 readiness snapshot for the workspace.")
+@Schema(description = "Operator-facing workspace readiness snapshot for the workspace.")
 public record WorkspaceReleaseReadinessResponse(
-        @Schema(description = "Overall Release 1 readiness for the currently configured workspace.")
+        @Schema(description = "Overall workspace readiness for the currently configured workspace.")
         WorkspaceCapabilityReadiness readiness,
         @Schema(description = "Short summary of the current release posture.")
         String summary,
-        @Schema(description = "Readiness checks for the Release 1 product slice.")
+        @Schema(description = "Readiness checks for the core product slice.")
         List<WorkspaceReleaseReadinessCheckResponse> checks,
         @Schema(description = "Outstanding operator actions extracted from the failing checks.")
         List<String> actions) {

--- a/src/main/java/com/massimotter/weave/backend/model/calendar/CalendarClientSetupOptionResponse.java
+++ b/src/main/java/com/massimotter/weave/backend/model/calendar/CalendarClientSetupOptionResponse.java
@@ -9,7 +9,7 @@ public record CalendarClientSetupOptionResponse(
         String platform,
         @Schema(description = "Setup mechanism.", example = "mobileconfig")
         String method,
-        @Schema(description = "Whether this setup method is currently safe for Release 2 use.", example = "false")
+        @Schema(description = "Whether this setup method is currently safe for feature-gated use.", example = "false")
         boolean available,
         @Schema(description = "Optional action URL for supported external clients. Contains no credential.")
         String actionUrl,

--- a/src/main/java/com/massimotter/weave/backend/service/BoardsFacadeService.java
+++ b/src/main/java/com/massimotter/weave/backend/service/BoardsFacadeService.java
@@ -41,7 +41,7 @@ public class BoardsFacadeService {
                     .toList();
             return new BoardsPreviewResponse(
                     true,
-                    "post-release-hidden-preview",
+                    "active-feature-gated-preview",
                     "local-preview-backend-facade",
                     boardsRepository.capabilities(),
                     projects,
@@ -111,7 +111,7 @@ public class BoardsFacadeService {
         Map<String, Object> details = new LinkedHashMap<>();
         details.put("module", "boards");
         details.put("preview", true);
-        details.put("releaseStatus", "post-release-hidden-preview");
+        details.put("releaseStatus", "active-feature-gated-preview");
         details.putAll(exception.details());
         return new ApiErrorException(status, "boards-" + exception.code().contractName(), exception.getMessage(), details);
     }

--- a/src/main/java/com/massimotter/weave/backend/service/CalendarFacadeService.java
+++ b/src/main/java/com/massimotter/weave/backend/service/CalendarFacadeService.java
@@ -152,7 +152,7 @@ public class CalendarFacadeService {
                                 "Signed .mobileconfig download remains fail-closed until profile signing and revocable credentials are implemented.",
                                 List.of(
                                         "iOS, iPadOS, and macOS can install a CalDAV configuration profile with host, port, SSL, principal URL, and username.",
-                                        "Release 2 must not embed a permanent password or backend service credential in the profile.",
+                                        "Profile generation must not embed a permanent password or backend service credential in the profile.",
                                         "The backend route is reserved for a signed no-secret profile and currently returns 503 rather than serving an unsigned artifact.")),
                         new CalendarClientSetupOptionResponse(
                                 "android",
@@ -210,11 +210,11 @@ public class CalendarFacadeService {
         return new CalendarAccessPolicyResponse(
                 accessModel(),
                 List.of("workspace-calendar.read", "workspace-calendar.write", "client-setup.metadata"),
-                List.of("private-user-calendar.read", "backend-actor-private-user-calendar.read"),
+                List.of("private-personal-calendar.read", "backend-actor-private-personal-calendar.read"),
                 List.of(
                         "Choose and document a private calendar access model: user sharing/provisioning, Nextcloud Login Flow/app password, delegated token exchange, or a Weave token bridge.",
                         "Add operator diagnostics proving private calendar templates are explicitly authorized.",
-                        "Add revocation and audit tests before any private user CalDAV endpoint is enabled."),
+                        "Add revocation and audit tests before any private personal CalDAV endpoint is enabled."),
                 false);
     }
 
@@ -419,7 +419,7 @@ public class CalendarFacadeService {
                 "external clients use user-owned revocable per-client credentials; backend actor credentials are never issued to clients",
                 List.of(
                         "The product calendar facade exposes workspace, team, and channel scope metadata.",
-                        "Backend CalDAV configuration that targets arbitrary private user calendars must stay fail-closed.",
+                        "Backend CalDAV configuration that targets arbitrary private personal calendars must stay fail-closed.",
                         "External clients may use CalDAV discovery URLs, but credentials must come from a user-controlled revocable flow."));
     }
 

--- a/src/main/java/com/massimotter/weave/backend/service/WorkspaceReleaseReadinessService.java
+++ b/src/main/java/com/massimotter/weave/backend/service/WorkspaceReleaseReadinessService.java
@@ -111,7 +111,7 @@ public class WorkspaceReleaseReadinessService {
                     hasText(dependencyUrl)
                             ? "Chat is disabled even though a Matrix route is configured."
                             : "Chat is disabled for this workspace snapshot.",
-                    "Enable WEAVE_WORKSPACE_CHAT_ENABLED for the Release 1 workspace when chat should ship.");
+                    "Enable WEAVE_WORKSPACE_CHAT_ENABLED for the workspace when chat should ship.");
         };
     }
 
@@ -144,7 +144,7 @@ public class WorkspaceReleaseReadinessService {
                     hasText(dependencyUrl)
                             ? "Files are disabled even though a Nextcloud route is configured."
                             : "Files are disabled for this workspace snapshot.",
-                    "Enable WEAVE_WORKSPACE_FILES_ENABLED for the Release 1 workspace when files should ship.");
+                    "Enable WEAVE_WORKSPACE_FILES_ENABLED for the workspace when files should ship.");
         };
     }
 
@@ -164,11 +164,11 @@ public class WorkspaceReleaseReadinessService {
 
     private String summaryFor(WorkspaceCapabilityReadiness readiness, List<String> actions) {
         return switch (readiness) {
-            case READY -> "Release 1 workspace dependencies are configured and ready to ship.";
-            case BLOCKED -> "Release 1 is blocked until the first-party auth contract is complete.";
-            case DEGRADED -> "Release 1 is partially configured. " + actions.size()
+            case READY -> "workspace dependencies are configured and ready to ship.";
+            case BLOCKED -> "Workspace readiness is blocked until the first-party auth contract is complete.";
+            case DEGRADED -> "Workspace readiness is partially configured. " + actions.size()
                     + " operator action(s) remain before auth, chat, and files are all ready.";
-            case UNAVAILABLE -> "Release 1 readiness is unavailable.";
+            case UNAVAILABLE -> "workspace readiness is unavailable.";
         };
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -96,7 +96,7 @@ weave:
       provisioning-state: ${WEAVE_ONBOARDING_NEXTCLOUD_PROVISIONING_STATE:}
   profile:
     # Persistent product-profile override store for mutable fields accepted by PATCH /api/profile.
-    # Mount this path on durable storage for containerized Release 1 runs.
+    # Mount this path on durable storage for containerized runs.
     storage:
       path: ${WEAVE_PROFILE_STORAGE_PATH:./data/profile-overrides.json}
   interop:

--- a/src/main/resources/contracts/boards-preview.openapi.yaml
+++ b/src/main/resources/contracts/boards-preview.openapi.yaml
@@ -7,14 +7,14 @@ info:
     Hidden preview-only provider-neutral schema and route draft for future Boards/Tasks work.
     The runtime routes are disabled by default, require the normal authenticated Weave
     workspace boundary, use only a local/in-memory preview adapter, and do not publish
-    Boards/Tasks as a Release 1 product API.
+    Boards/Tasks as a live product API.
 paths:
   /api/boards/preview:
     get:
       summary: Read hidden Boards/Tasks preview snapshot
       responses:
         '200':
-          description: Provider-neutral hidden preview snapshot.
+          description: Provider-neutral feature-gated preview snapshot.
           content:
             application/json:
               schema:
@@ -24,7 +24,7 @@ paths:
         '503': { description: Preview runtime is disabled or unavailable. }
   /api/boards/{boardId}/tasks:
     post:
-      summary: Create a hidden preview task
+      summary: Create a feature-gated preview task
       parameters:
         - name: boardId
           in: path
@@ -45,7 +45,7 @@ paths:
                 $ref: '#/components/schemas/TaskItem'
   /api/boards/tasks/{taskId}/move:
     post:
-      summary: Move a hidden preview task without drag-and-drop
+      summary: Move a feature-gated preview task without drag-and-drop
       parameters:
         - name: taskId
           in: path
@@ -66,7 +66,7 @@ paths:
                 $ref: '#/components/schemas/TaskItem'
   /api/boards/tasks/{taskId}/complete:
     post:
-      summary: Complete a hidden preview task without drag-and-drop
+      summary: Complete a feature-gated preview task without drag-and-drop
       parameters:
         - name: taskId
           in: path
@@ -90,7 +90,7 @@ components:
         preview: { type: boolean }
         releaseStatus:
           type: string
-          enum: [post-release-hidden-preview]
+          enum: [active-feature-gated-preview]
         source:
           type: string
           enum: [local-preview-backend-facade]

--- a/src/main/resources/contracts/task-board-event.schema.json
+++ b/src/main/resources/contracts/task-board-event.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://weave.local/contracts/task-board-event.schema.json",
   "title": "TaskBoardEvent",
-  "description": "Preview-only normalized Boards/Tasks event envelope. Hidden for Release 1 until a promotion spec defines publication semantics.",
+  "description": "Preview-only normalized Boards/Tasks event envelope. Feature-gated until a promotion spec defines publication semantics.",
   "type": "object",
   "required": [
     "idempotencyKey",

--- a/src/test/java/com/massimotter/weave/backend/boards/BoardProviderSpikeContractsTest.java
+++ b/src/test/java/com/massimotter/weave/backend/boards/BoardProviderSpikeContractsTest.java
@@ -30,7 +30,7 @@ class BoardProviderSpikeContractsTest {
                 BoardCapability.WEBHOOK_EVENTS,
                 BoardCapability.INCREMENTAL_SYNC,
                 BoardCapability.ACCESSIBLE_NON_DRAG_MOVES);
-        assertThat(capabilities.supportSafeSummary()).contains("benchmark").contains("Release 1");
+        assertThat(capabilities.supportSafeSummary()).contains("benchmark").contains("disabled");
         assertThatThrownBy(() -> repository.listProjects(null))
                 .isInstanceOf(BoardsException.class)
                 .satisfies(error -> assertThat(((BoardsException) error).code())
@@ -56,7 +56,7 @@ class BoardProviderSpikeContractsTest {
                 BoardCapability.INCREMENTAL_SYNC,
                 BoardCapability.CUSTOM_FIELDS,
                 BoardCapability.ACCESSIBLE_NON_DRAG_MOVES);
-        assertThat(capabilities.supportSafeSummary()).contains("bridge").contains("Release 1");
+        assertThat(capabilities.supportSafeSummary()).contains("bridge").contains("disabled");
         assertThatThrownBy(() -> repository.listProjects(null))
                 .isInstanceOf(BoardsException.class)
                 .satisfies(error -> assertThat(((BoardsException) error).code())

--- a/src/test/java/com/massimotter/weave/backend/boards/BoardsPreviewContractTest.java
+++ b/src/test/java/com/massimotter/weave/backend/boards/BoardsPreviewContractTest.java
@@ -34,8 +34,8 @@ class BoardsPreviewContractTest {
                 .isInstanceOf(BoardsException.class)
                 .satisfies(error -> assertThat(((BoardsException) error).code())
                         .isEqualTo(BoardsErrorCode.PROVIDER_UNAVAILABLE))
-                .hasMessageContaining("hidden preview module")
-                .hasMessageContaining("Release 1");
+                .hasMessageContaining("feature-gated preview module")
+                .hasMessageContaining("runtime validation");
     }
 
     @Test
@@ -134,7 +134,7 @@ class BoardsPreviewContractTest {
         assertThat(contract).contains("title: Weave Boards/Tasks Preview Contract");
         assertThat(contract).contains("/api/boards/preview");
         assertThat(contract).contains("/api/boards/{boardId}/tasks");
-        assertThat(contract).contains("post-release-hidden-preview");
+        assertThat(contract).contains("active-feature-gated-preview");
         assertThat(contract).contains("TaskBoardEvent");
         assertThat(contract).contains("task.moved");
     }

--- a/src/test/java/com/massimotter/weave/backend/boards/VikunjaBoardsMapperTest.java
+++ b/src/test/java/com/massimotter/weave/backend/boards/VikunjaBoardsMapperTest.java
@@ -26,7 +26,7 @@ class VikunjaBoardsMapperTest {
         var source = new VikunjaProjectSnapshot(
                 42,
                 "Launch Plan",
-                "Coordinate Release 1 follow-ups",
+                "Coordinate active product follow-ups",
                 false,
                 URI.create("https://tasks.weave.local/projects/42"));
 
@@ -45,7 +45,7 @@ class VikunjaBoardsMapperTest {
         assertThat(board.id()).isEqualTo("vikunja:board:42");
         assertThat(board.projectId()).isEqualTo("vikunja:project:42");
         assertThat(board.name()).isEqualTo("Launch Plan");
-        assertThat(board.description()).isEqualTo("Coordinate Release 1 follow-ups");
+        assertThat(board.description()).isEqualTo("Coordinate active product follow-ups");
         assertThat(board.archived()).isFalse();
     }
 

--- a/src/test/java/com/massimotter/weave/backend/controller/BoardsControllerTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/BoardsControllerTest.java
@@ -64,7 +64,7 @@ class BoardsControllerTest {
                         .with(workspaceJwt()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.preview").value(true))
-                .andExpect(jsonPath("$.releaseStatus").value("post-release-hidden-preview"))
+                .andExpect(jsonPath("$.releaseStatus").value("active-feature-gated-preview"))
                 .andExpect(jsonPath("$.source").value("local-preview-backend-facade"))
                 .andExpect(jsonPath("$.capabilities.enabled").value(true))
                 .andExpect(jsonPath("$.projects[0].id").value("local-project-1"))

--- a/src/test/java/com/massimotter/weave/backend/controller/PlatformProductContractControllerTest.java
+++ b/src/test/java/com/massimotter/weave/backend/controller/PlatformProductContractControllerTest.java
@@ -148,7 +148,7 @@ class PlatformProductContractControllerTest {
         mockMvc.perform(get("/api/calendar/access-policy").with(workspaceJwt()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.backendActorMayReadPrivateUserCalendars").value(false))
-                .andExpect(jsonPath("$.deniedScopes[0]").value("private-user-calendar.read"));
+                .andExpect(jsonPath("$.deniedScopes[0]").value("private-personal-calendar.read"));
 
         MvcResult created = mockMvc.perform(post("/api/calendar/client-setup/credentials")
                         .with(workspaceJwt())

--- a/src/test/java/com/massimotter/weave/backend/service/BoardsFacadeServiceTest.java
+++ b/src/test/java/com/massimotter/weave/backend/service/BoardsFacadeServiceTest.java
@@ -22,7 +22,7 @@ class BoardsFacadeServiceTest {
                     assertThat(error.code()).isEqualTo("boards-provider_unavailable");
                     assertThat(error.details()).containsEntry("module", "boards");
                     assertThat(error.details()).containsEntry("preview", true);
-                    assertThat(error.details()).containsEntry("releaseStatus", "post-release-hidden-preview");
+                    assertThat(error.details()).containsEntry("releaseStatus", "active-feature-gated-preview");
                 });
     }
 }

--- a/src/test/java/com/massimotter/weave/backend/service/calendar/CalDavCalendarAdapterTest.java
+++ b/src/test/java/com/massimotter/weave/backend/service/calendar/CalDavCalendarAdapterTest.java
@@ -54,7 +54,7 @@ class CalDavCalendarAdapterTest {
                 .satisfies(error -> {
                     CalendarAdapterException adapterError = (CalendarAdapterException) error;
                     assertThat(adapterError.type()).isEqualTo(CalendarAdapterException.Type.NOT_CONFIGURED);
-                    assertThat(adapterError.details()).containsEntry("calendarScope", "private-user");
+                    assertThat(adapterError.details()).containsEntry("calendarScope", "private-personal");
                     assertThat(adapterError.details()).containsEntry("privateUserTemplateAllowed", false);
                 });
     }


### PR DESCRIPTION
## Summary
- Reframes backend docs/contracts/tests away from Release 1/2 and post-release wording toward active feature-gated Calendar and Boards scope.
- Clarifies Calendar facade/private-personal boundaries and Teams-like workspace/team/channel target.
- Marks Boards preview as active feature-gated, not live-provider-enabled, and adds Calendar facade test coverage for private-personal fail-closed copy.

## Tracking issues
- #56 (updated)
- #66
- #67
- #68
- #69

## Validation
- ./gradlew test