### PR TITLE
fix(calendar): create missing CalDAV collection lazily

### DIFF
--- a/src/main/java/com/massimotter/weave/backend/service/calendar/CalDavCalendarAdapter.java
+++ b/src/main/java/com/massimotter/weave/backend/service/calendar/CalDavCalendarAdapter.java
@@ -31,6 +31,8 @@ import org.xml.sax.InputSource;
 public class CalDavCalendarAdapter implements CalendarAdapter {
 
     private static final int HTTP_MULTI_STATUS = 207;
+    private static final int HTTP_NOT_FOUND = 404;
+    private static final int HTTP_METHOD_NOT_ALLOWED = 405;
     private static final DateTimeFormatter CALDAV_TIME_RANGE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'")
             .withZone(ZoneOffset.UTC);
 
@@ -62,6 +64,10 @@ public class CalDavCalendarAdapter implements CalendarAdapter {
                 .header("Accept", "application/xml, text/xml")
                 .build();
         HttpResponse<String> response = send(request, "list-events");
+        if (response.statusCode() == HTTP_NOT_FOUND) {
+            ensureCalendarCollection(principal);
+            response = send(request, "list-events");
+        }
         if (response.statusCode() != HTTP_MULTI_STATUS && !isSuccess(response.statusCode())) {
             throw mapStatus(response.statusCode(), "list-events", null);
         }
@@ -80,6 +86,10 @@ public class CalDavCalendarAdapter implements CalendarAdapter {
                 .header("If-None-Match", "*")
                 .build();
         HttpResponse<String> response = send(httpRequest, "create-event");
+        if (response.statusCode() == HTTP_NOT_FOUND) {
+            ensureCalendarCollection(principal);
+            response = send(httpRequest, "create-event");
+        }
         if (!isSuccess(response.statusCode())) {
             throw mapStatus(response.statusCode(), "create-event", href);
         }
@@ -212,6 +222,22 @@ public class CalDavCalendarAdapter implements CalendarAdapter {
                 """.formatted(timeRange);
     }
 
+    private String mkCalendarBody() {
+        return """
+                <?xml version="1.0" encoding="utf-8" ?>
+                <c:mkcalendar xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+                  <d:set>
+                    <d:prop>
+                      <d:displayname>Weave workspace calendar</d:displayname>
+                      <c:supported-calendar-component-set>
+                        <c:comp name="VEVENT" />
+                      </c:supported-calendar-component-set>
+                    </d:prop>
+                  </d:set>
+                </c:mkcalendar>
+                """;
+    }
+
     private HttpRequest.Builder requestBuilder(URI uri) {
         HttpRequest.Builder builder = HttpRequest.newBuilder(uri)
                 .timeout(Duration.ofSeconds(properties.requestTimeoutSeconds()))
@@ -256,6 +282,21 @@ public class CalDavCalendarAdapter implements CalendarAdapter {
         }
     }
 
+    private void ensureCalendarCollection(CalendarPrincipal principal) {
+        URI calendarUri = calendarCollectionUri(principal);
+        HttpRequest request = requestBuilder(calendarUri)
+                .method("MKCALENDAR", HttpRequest.BodyPublishers.ofString(mkCalendarBody()))
+                .header("Content-Type", "application/xml; charset=utf-8")
+                .build();
+        HttpResponse<String> response = send(request, "ensure-calendar-collection");
+        if (isSuccess(response.statusCode())
+                || response.statusCode() == HTTP_MULTI_STATUS
+                || response.statusCode() == HTTP_METHOD_NOT_ALLOWED) {
+            return;
+        }
+        throw mapStatus(response.statusCode(), "ensure-calendar-collection", calendarHref(principal, ""));
+    }
+
     private CalendarAdapterException mapStatus(int status, String operation, String href) {
         Map<String, Object> details = href == null
                 ? Map.of("module", "calendar", "operation", operation, "downstreamStatus", status)
@@ -265,7 +306,7 @@ public class CalDavCalendarAdapter implements CalendarAdapter {
                     CalendarAdapterException.Type.AUTH_FAILED,
                     "CalDAV backend actor was not authorized.", details);
         }
-        if (status == 404) {
+        if (status == HTTP_NOT_FOUND) {
             return new CalendarAdapterException(
                     CalendarAdapterException.Type.NOT_FOUND,
                     "Calendar event was not found.", details);

--- a/src/test/java/com/massimotter/weave/backend/service/calendar/CalDavCalendarAdapterTest.java
+++ b/src/test/java/com/massimotter/weave/backend/service/calendar/CalDavCalendarAdapterTest.java
@@ -152,6 +152,44 @@ END:VCALENDAR&#13;
         assertThat(updated.title()).isEqualTo("Updated");
     }
 
+    @Test
+    void createsBackendActorCalendarWhenCreateFindsMissingCollection() throws Exception {
+        List<String> methods = new ArrayList<>();
+        List<String> paths = new ArrayList<>();
+        List<String> requestBodies = new ArrayList<>();
+        server = server(exchange -> {
+            methods.add(exchange.getRequestMethod());
+            paths.add(exchange.getRequestURI().getRawPath());
+            requestBodies.add(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+            if ("PUT".equals(exchange.getRequestMethod()) && methods.size() == 1) {
+                respond(exchange, 404, "", null);
+            } else if ("MKCALENDAR".equals(exchange.getRequestMethod())) {
+                respond(exchange, 201, "", null);
+            } else if ("PUT".equals(exchange.getRequestMethod())) {
+                respond(exchange, 201, "", "\"etag-new\"");
+            } else {
+                respond(exchange, 405, "", null);
+            }
+        });
+
+        var created = adapter().create(principal(), new CreateCalendarEventRequest(
+                "Planning",
+                null,
+                OffsetDateTime.parse("2026-04-26T10:00:00+02:00"),
+                OffsetDateTime.parse("2026-04-26T11:00:00+02:00"),
+                "Europe/Berlin",
+                null,
+                false));
+
+        assertThat(methods).containsExactly("PUT", "MKCALENDAR", "PUT");
+        assertThat(paths.get(0)).startsWith("/remote.php/dav/calendars/weave-backend/personal/");
+        assertThat(paths.get(1)).isEqualTo("/remote.php/dav/calendars/weave-backend/personal/");
+        assertThat(paths.get(2)).isEqualTo(paths.get(0));
+        assertThat(requestBodies.get(1)).contains("Weave workspace calendar");
+        assertThat(created.title()).isEqualTo("Planning");
+        assertThat(created.etag()).isEqualTo("\"etag-new\"");
+    }
+
     private CalDavCalendarAdapter adapter() {
         return new CalDavCalendarAdapter(new CalendarCalDavProperties(
                 "http://localhost:" + server.getAddress().getPort(),


### PR DESCRIPTION
## Problem
Live Stack E2E exposed a Calendar facade failure when the Nextcloud backend actor's `personal` CalDAV collection was missing and infra could not pre-create it because `dav:create-calendar` was unavailable. Event creation surfaced `Calendar event was not found.` from the downstream 404.

## Target behavior
The backend CalDAV adapter keeps the product API stable and self-heals a missing backend-actor workspace calendar collection by issuing `MKCALENDAR`, then retrying the failed list/create request.

## Changes
- Retry Calendar list/create once after a 404 by ensuring the configured CalDAV collection exists.
- Add a CalDAV adapter test proving event creation recovers via `MKCALENDAR` and then succeeds.

## Validation
- `./gradlew test --tests com.massimotter.weave.backend.service.calendar.CalDavCalendarAdapterTest`
- `./gradlew test`
- `./gradlew build`

## Contract impact
No public API contract change. This hardens the backend-owned Nextcloud/CalDAV adapter behind the existing Calendar facade.
